### PR TITLE
Fix broken email link on index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ researcher or instructor at UAB.
 
 ## Contact Us
 
-To create a support ticket please reach out to us via email at support@listserv.uab.edu.
+To create a support ticket please reach out to us via email at <support@listserv.uab.edu>.
 
 You can also visit us in our Zoom office hours held weekly:
 


### PR DESCRIPTION
Fixes #112 

Makes email address in contact-us on index.md a mailto: link.