### PR TITLE
Change links in content to be more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The workaround is needed because `markdownlint` has no plans to add support for 
 ### Accessibility
 
 Color vision deficiency checker: <https://www.toptal.com/designers/colorfilter/>
+Contrast checker: <https://webaim.org/resources/contrastchecker/>
 
 ### Branding Guidance
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -6,6 +6,23 @@
   max-width: 100%;
 }
 
+.md-content a {
+  color: revert;
+}
+
+.md-content a:visited {
+  color: revert;
+}
+
+.md-content a:hover {
+  color: revert;
+  border-bottom: 1px solid;
+}
+
+.md-typeset .headerlink:hover {
+  border-bottom: none;
+}
+
 html .md-footer-meta.md-typeset a.supportemail {
   color: #aaaaff;
 }


### PR DESCRIPTION
Fixes #146 

Changes links in primary content to match browser link colors. Adds underline on hover, rather than color change. No effect on other colors.

This will make it lots easier to identify what text IS a link, what links have been visited before, and what links are hovered. It also matches the exact UX of each browser automatically (yay `revert`).