### PR TITLE
fixed missing centering on alttext

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,10 @@ There is no way to fix this automatically, so we rely on checking and reporting.
 
 Currently Prettier bulleted list indenting is wonky for markdown. In addition to indenting list markers, it pads out spaces after the marker. Please see [this issue](https://github.com/prettier/prettier/issues/5019) for more details. As a result, we can't automatically format markdown documents, so we need to rely on spotting incorrect indents. Use the following regex `^[ ]{1,3}[^ ]`. It will search for one to three spaces followed by a not-space character.
 
+#### Checking Images are Centered
+
+Our preference is that images be centered at their indentation level. To do this, we need `><` at the end of the alternate text bracket. An example is shown below.
+
+`![!alttext ><](./path/to/image.png)`
+
+To discover images that are missing the centering characters, use regex `!\[.*[^<]\]\(`.

--- a/docs/account_management/uab_researcher.md
+++ b/docs/account_management/uab_researcher.md
@@ -4,7 +4,7 @@ These instructions are for researchers at UAB to request their own accounts on C
 
 Navigate to <https://rc.uab.edu>, authenticate with your UAB credentials, and if you do not have a Cheaha account, you will see the page shown below:
 
-![!UAB Self Register page.](./images/uab_self_register.png)
+![!UAB Self Register page. ><](./images/uab_self_register.png)
 
 Your BlazerID and full name will already be filled in based on your authentication credentials. Please fill out a reason for needing a Cheaha account and press `Create Account`. Your account should be created and ready to use.
 

--- a/docs/account_management/xias_sites.md
+++ b/docs/account_management/xias_sites.md
@@ -30,4 +30,4 @@ XIAS Project/Sites, or simply sites, tie external users to specific resources at
 
 5. When you visit the "Manage Projects/Sites" page in the future, you will see a table with the newly created Project/Site listed. Click "View" to return to the page seen in the previous step. Click "Edit" to return to the form from \[link\]. Click "Users" to manage users for this site.
 
-    ![!Site table with newly created site listed. On that row are three buttons: View, Edit, Users. On the next row is the button New.](./images/xias_sites_add_004.png)
+    ![!Site table with newly created site listed. On that row are three buttons: View, Edit, Users. On the next row is the button New. ><](./images/xias_sites_add_004.png)

--- a/docs/data_management/transfer/filezilla.md
+++ b/docs/data_management/transfer/filezilla.md
@@ -10,7 +10,7 @@ To download the program, go to [the FileZilla site](https://filezilla-project.or
 
 Once FileZilla is installed and you open it, you will see the following window
 
-![!FileZilla window.](./images/filezilla_on_startup.png)
+![!FileZilla window. ><](./images/filezilla_on_startup.png)
 
 A file browser for the local machine FileZilla is running on is on the left while the file system for the remote site will be shown on the right once a remote site has been connected.
 
@@ -25,7 +25,7 @@ You can easily connect to a remote site using the QuickConnect bar near the top 
 
 Click `Quickconnect` and you will be connected to the remote storage system. The window should now look like:
 
-![!Remote connection showing on the right side of the FileZilla window.](./images/filezilla_connected.png)
+![!Remote connection showing on the right side of the FileZilla window. ><](./images/filezilla_connected.png)
 
 When connecting in the future, you will be able to select the connection from the dropdown arrow next to the Quickconnect button.
 

--- a/docs/uab_cloud/volume_setup_basic.md
+++ b/docs/uab_cloud/volume_setup_basic.md
@@ -61,7 +61,7 @@ To format a volume, you must have created a volume and attached it to an instanc
 
 2. Scroll down to "Volumes Attached" and make note of the `<mount>` part of `<volume-name> on <mount>` for your attached volume as it will be used in later steps.
 
-    ![!my_instance overview page. The page has been scrolled to the bottom. The mouse is pointing to a label under the Volumes Attached heading. The mouse is pointing to the Attached To label reading my_volume on /dev/vdb.](./images/persistent_volumes_000.png)
+    ![!my_instance overview page. The page has been scrolled to the bottom. The mouse is pointing to a label under the Volumes Attached heading. The mouse is pointing to the Attached To label reading my_volume on /dev/vdb. ><](./images/persistent_volumes_000.png)
 
 3. SSH into the instance from your local machine or from Cheaha.
 
@@ -82,7 +82,7 @@ To format a volume, you must have created a volume and attached it to an instanc
     9. Enter `p` to display the partition setup. Note that the partition will be labeled `<mount>1`. This literally whatever `<mount>` was from earlier followed by the numeral `1`. Further steps will refer to this as `<pmount>`
     10. Enter `w` to execute the setup prepared in the previous substeps.
 
-    ![!MINGW64 terminal. The sudo fdisk /dev/vdb command has been entered. Also shown are the various prompts guiding through the process of formatting the disk. The final command was the literal character w, which executed the previously entered commands.](./images/persistent_volumes_002.png)
+    ![!MINGW64 terminal. The sudo fdisk /dev/vdb command has been entered. Also shown are the various prompts guiding through the process of formatting the disk. The final command was the literal character w, which executed the previously entered commands. ><](./images/persistent_volumes_002.png)
 
 6. Verify the volume is not mounted using `sudo mount | egrep "<mount>"`. If there is no output, then move to the next step. If there is some output then use `sudo umount -l "<mount>"` to unmount the volume and verify again.
 


### PR DESCRIPTION
Fixed a number of images with missing centering directives (`><`).

Also added a regex to the dev section of the README for spotting them.