### PR TITLE
Improvements to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: ci
 on:
   push:
     branches:
-      - dev
       - main
 jobs:
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,27 @@
-name: ci 
+name: ci
 
 on:
   push:
     branches:
+      - dev
       - main
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+
+      - name: Install environment
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: 3.x
-      - run: pip install mkdocs-material 
-      - run: pip install lightgallery
-      - run: pip3 install mkdocs-table-reader-plugin
-      - run: mkdocs gh-deploy --force
+          environment-file: build_env.yml
+          environment-name: build
+          cache-downloads: true
+          cache-env: true
+
+      - name: Build pages
+        shell: bash -l {0}
+        run: |
+          micromamba activate build
+          mkdocs gh-deploy --force

--- a/build_env.yml
+++ b/build_env.yml
@@ -1,44 +1,16 @@
 name: mkdocs
 channels:
-  - defaults
+  - anaconda
+  - conda-forge
 dependencies:
-  - ca-certificates=2021.10.26=haa95532_2
-  - certifi=2021.10.8=py39haa95532_0
-  - openssl=1.1.1l=h2bbff1b_0
-  - pip=21.2.4=py39haa95532_0
-  - python=3.9.7=h6244533_1
-  - setuptools=58.0.4=py39haa95532_0
-  - sqlite=3.37.0=h2bbff1b_0
-  - tzdata=2021e=hda174b7_0
-  - vc=14.2=h21ff451_1
-  - vs2015_runtime=14.27.29016=h5e58377_2
-  - wheel=0.37.1=pyhd3eb1b0_0
-  - wincertstore=0.2=py39haa95532_2
+  - jinja2=3.0.3
+  - markupsafe=2.0.1
+  - mkdocs=1.2.3
+  - mkdocs-material=8.1.6
+  - mkdocs-material-extensions=1.0.3
+  - mkdocs-table-reader-plugin=1.0.0
+  - pip=21.2.4
+  - python=3.9.7
   - pip:
-      - click==8.0.3
-      - colorama==0.4.4
-      - ghp-import==2.0.2
-      - importlib-metadata==4.10.0
-      - jinja2==3.0.3
       - lightgallery==0.5
-      - markdown==3.3.6
-      - markupsafe==2.0.1
-      - mergedeep==1.3.4
-      - mkdocs==1.2.3
-      - mkdocs-material==8.1.6
-      - mkdocs-material-extensions==1.0.3
-      - mkdocs-table-reader-plugin==1.0.0
-      - numpy==1.22.1
-      - packaging==21.3
-      - pandas==1.4.0
-      - pygments==2.11.2
-      - pymdown-extensions==9.1
-      - pyparsing==3.0.6
-      - python-dateutil==2.8.2
-      - pytz==2021.3
-      - pyyaml==6.0
-      - pyyaml-env-tag==0.1
-      - six==1.16.0
-      - tabulate==0.8.9
-      - watchdog==2.1.6
-      - zipp==3.7.0
+      - mkdocs-redirects==1.0.4


### PR DESCRIPTION
Made `build_env.yml` minimal.

CI uses conda and mamba and `build_env.yml` to build the docs.