### PR TITLE
Strict build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         shell: bash -l {0}
         run: |
           micromamba activate build
-          mkdocs gh-deploy --force
+          mkdocs gh-deploy --force --strict

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Before you can get started working on contributions, you'll need a copy of the r
 
 Once the fork has been created, you can clone your fork using the Command Palette (`ctrl + shift + p`) and `Git: Clone...` in VSCode, or at the command line. More information on cloning can be found at [GitHub: Cloning a Repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
 
-### Local Machine Setup (Laptop/Desktop)
+#### Local Machine Setup (Laptop/Desktop)
 
 The Python extension will activate when you open any Python file. The file `test.py` has been added for convenience, simply open that file to activate the extension. The extension will show the currently activated environment near the bottom-left corner of the VSCode window.
 
@@ -54,7 +54,9 @@ conda env create -f build_env.yml
 
 Activate the environment in VSCode by clicking the currently activated environment in the bottom-left of the VSCode window. A menu will appear allowing you to select from discovered environments. You may need to reload VSCode to get the environment to appear if it was just created.
 
-### GitHub Setup
+To build the documentation locally, use `mkdocs build`. Be sure to fix all warnings before submitting a pull request.
+
+#### GitHub Setup
 
 To view your changes as they would appear on the official documentation website, you'll need to set up GitHub Pages in your fork. Navigate to your fork repository URL and click the "Settings" tab. Click "Pages" under "Code and automation". Follow the instructions here to set up a source: [GitHub Pages Docs](https://docs.github.com/en/pages).
 
@@ -84,6 +86,15 @@ To Be Determined
 
 ### Formatting
 
+- Links must be one of the following formats including all punctuation and brackets:
+    - Bare:
+        - `<https://google.com>`
+        - `<support@listserv.uab.edu>`
+    - Named with a schema:
+        - `[website](https://google.com)`
+        - `[email](mailto:support@listserv.uab.edu)` note the `mailto:` schema!
+    - Relative internal
+        - `[relative internal](help/faq.md)`
 - All internal links must be relative. For example, use `./file.md` not `/docs/file.md`.
 
 ### Linting Known Issues

--- a/docs/data_management/LTS/lts.md
+++ b/docs/data_management/LTS/lts.md
@@ -24,7 +24,7 @@ This documentation will use the standard file and path terms since that's more e
 
 ## Requesting an Account
 
-UAB researchers do not have automatic access to LTS, and currently, single sign on is not enabled. To request access to LTS, please send an email to [support@listserv.uab.edu](support@listserv.uab.edu). You will be then be given an Access Key and a Secret Access Key, both of which will be used later on. Keep track of both of these keys and do not share them with anyone else, these are your login credentials for LTS.
+UAB researchers do not have automatic access to LTS, and currently, single sign on is not enabled. To request access to LTS, please send an email to <support@listserv.uab.edu>. You will be then be given an Access Key and a Secret Access Key, both of which will be used later on. Keep track of both of these keys and do not share them with anyone else, these are your login credentials for LTS.
 
 ## Windows/Mac
 
@@ -55,7 +55,7 @@ The bucket will have the symbol of a hard disk with an Amazon A brand on it. Thi
 <!-- markdownlint-disable MD046 -->
 !!! important
 
-    Bucket names are shared across all LTS. This means you cannot create a bucket with a name that has already been created by someone else, even if that bucket is not shared with you. When creating bucket names, make them specific and/or unique. For example, davislab for storing data for the entire Davis lab or the name of a specific dataset that is being stored. Do not make names like trial or my-storage. 
+    Bucket names are shared across all LTS. This means you cannot create a bucket with a name that has already been created by someone else, even if that bucket is not shared with you. When creating bucket names, make them specific and/or unique. For example, davislab for storing data for the entire Davis lab or the name of a specific dataset that is being stored. Do not make names like trial or my-storage.
 <!-- markdownlint-enable MD046 -->
 
 ### Uploading and Downloading Data
@@ -154,10 +154,10 @@ New settings:
   Default Region: US
   S3 Endpoint: s3.lts.rc.uab.edu
   DNS-style bucket+hostname:port template for accessing a bucket: %(bucket).s3.lts.rc.uab.edu
-  Encryption password: 
+  Encryption password:
   Path to GPG program: $HOME/bin/gpg
   Use HTTPS protocol: True
-  HTTP Proxy server name: 
+  HTTP Proxy server name:
   HTTP Proxy server port: 0
 
 Test access with supplied credentials? [Y/n] Y
@@ -242,7 +242,7 @@ Buckets are essentially the root folder of a filesystem where you are storing yo
 <!-- markdownlint-disable MD046 -->
 !!! important
 
-    Bucket names are shared across all LTS. This means you cannot create a bucket with a name that has already been created by someone else, even if that bucket is not shared with you. When creating bucket names, make them specific and/or unique. For example, davislab for storing data for the entire Davis lab or the name of a specific dataset that is being stored. Do not make names like trial or my-storage. 
+    Bucket names are shared across all LTS. This means you cannot create a bucket with a name that has already been created by someone else, even if that bucket is not shared with you. When creating bucket names, make them specific and/or unique. For example, davislab for storing data for the entire Davis lab or the name of a specific dataset that is being stored. Do not make names like trial or my-storage.
 <!-- markdownlint-enable MD046 -->
 
 **RClone**:
@@ -425,7 +425,7 @@ aws s3 rm s3://<bucket/path/object> --endpoint-url https://s3.lts.rc.uab.edu [--
 To delete an entire bucket, you will need to use the `s3api` command paired with the `delete-bucket subcommand. An example of this looks like:
 
 ``` bash
-aws s3api delete-bucket --bucket <bucket> --endpoint-url https://s3.lts.rc.uab.edu 
+aws s3api delete-bucket --bucket <bucket> --endpoint-url https://s3.lts.rc.uab.edu
 ```
 
 ### Command Comparison Chart
@@ -436,14 +436,14 @@ aws s3api delete-bucket --bucket <bucket> --endpoint-url https://s3.lts.rc.uab.e
     For brevity, the chart will exclude the `--endpoint-url` option from the AWS CLI commands, but it will need to be included if you choose to use that tool.
 <!-- markdownlint-enable MD046 -->
 
-| Action | rclone | s3cmd | AWS CLI |
-|--------|--------|-------|---------|
-| Make Bucket | `rclone mkdir uablts:<bucket>` | `s3cmd mb s3://<bucket>` | `aws s3api create-bucket --bucket <bucket>` |
-| List Buckets | `rclone lsd uablts:` | `s3cmd ls` | `aws s3 ls` |
-| List Files | `rclone lsf uablts:<bucket/path/>` | `s3cmd ls s3://<bucket/path/>` | `aws s3 ls s3://<bucket/path/>` |
-| Full Upload | `rclone copy <source> uablts:<bucket/destination>` | `s3cmd put <source> s3://<bucket/destination/>` | `aws s3 cp <source> s3://<bucket/destination>` |
-| Download | `rclone copy uablts:<bucket/source/> <destination>` | `s3cmd get s3://<bucket/source/> <destination>` | `aws s3 cp s3://<bucket/source/> <destination>` |
-| Sync | `rclone sync [-i] <source> uablts:<bucket/destination/>` | `s3cmd sync <source> s3://<bucket/destination/>` | `aws s3 sync <source> s3://<bucket/destination/> [--delete]`
-| Delete File | `rclone delete uablts:<bucket/path/file>` | `s3cmd rm s3://<bucket/path/file>` | `aws s3 rm s3://<bucket/path/file>` |
-| Delete Folder | `rclone purge uablts:<bucket/path/>` | `s3cmd rm s3://<bucket/path/> --recursive` | `aws s3 rm s3://<bucket/path/> --recursive` |
-| Delete Bucket | `rclone purge uablts:<bucket>` | `s3cmd rb s3://<bucket>` | `aws s3api delete-bucket --bucket <bucket>` |
+| Action        | rclone                                                   | s3cmd                                            | AWS CLI                                                      |
+| ------------- | -------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------ |
+| Make Bucket   | `rclone mkdir uablts:<bucket>`                           | `s3cmd mb s3://<bucket>`                         | `aws s3api create-bucket --bucket <bucket>`                  |
+| List Buckets  | `rclone lsd uablts:`                                     | `s3cmd ls`                                       | `aws s3 ls`                                                  |
+| List Files    | `rclone lsf uablts:<bucket/path/>`                       | `s3cmd ls s3://<bucket/path/>`                   | `aws s3 ls s3://<bucket/path/>`                              |
+| Full Upload   | `rclone copy <source> uablts:<bucket/destination>`       | `s3cmd put <source> s3://<bucket/destination/>`  | `aws s3 cp <source> s3://<bucket/destination>`               |
+| Download      | `rclone copy uablts:<bucket/source/> <destination>`      | `s3cmd get s3://<bucket/source/> <destination>`  | `aws s3 cp s3://<bucket/source/> <destination>`              |
+| Sync          | `rclone sync [-i] <source> uablts:<bucket/destination/>` | `s3cmd sync <source> s3://<bucket/destination/>` | `aws s3 sync <source> s3://<bucket/destination/> [--delete]` |
+| Delete File   | `rclone delete uablts:<bucket/path/file>`                | `s3cmd rm s3://<bucket/path/file>`               | `aws s3 rm s3://<bucket/path/file>`                          |
+| Delete Folder | `rclone purge uablts:<bucket/path/>`                     | `s3cmd rm s3://<bucket/path/> --recursive`       | `aws s3 rm s3://<bucket/path/> --recursive`                  |
+| Delete Bucket | `rclone purge uablts:<bucket>`                           | `s3cmd rb s3://<bucket>`                         | `aws s3api delete-bucket --bucket <bucket>`                  |

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -8,11 +8,11 @@ Below are some common issues, their most common causes, and their most common re
 
 #### Why is my account on hold?
 
-There are a number of reasons your account was placed on hold. Please see [Account on Hold](../account_management/uab_researcher.md#account-on-hold) for more information.
+There are a number of reasons your account was placed on hold. Please see [Account on Hold](../account_management/cheaha_account.md#account-on-hold) for more information.
 
 #### Why is my account not authorized?
 
-There are a number of reasons your account may not be authorized. Please see [Account Authorization Error](../account_management/uab_researcher.md#authorization-error) for more information.
+There are a number of reasons your account may not be authorized. Please see [Account Authorization Error](../account_management/cheaha_account.md#authorization-error) for more information.
 
 ### Common Issues
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,6 @@ repo_url: https://github.com/uabrc/researcher-facing-MkDocs
 
 theme:
   name: material
-  include_search_page: true
   search_index_only: true
   feature:
     tabs: true


### PR DESCRIPTION
Fixes #239 
Fixes #9 

- Fixed broken links
- Removed spurious warning about search.html
- Added --strict flag to mkdocs gh-deploy
- Added notes to contributor guide about link types

This PR does NOT work with external link, only internal links. I will make a separate issue for external link checking, which will take a different library or plugin.