### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Our documentation is available at <https://uabrc.github.io/>.
 
 ## Contributing
 
-Please see <https://uabrc.github.io/contributor_guide.md>.
+Please see <https://uabrc.github.io/contributor_guide/>.
 
 ## Developer Notes
 


### PR DESCRIPTION
Quick fix for a broken link in the readme pointing to the contributor guide.