### PR TITLE
Fix breaking env

### DIFF
--- a/build_env.yml
+++ b/build_env.yml
@@ -4,6 +4,7 @@ channels:
   - anaconda
 dependencies:
   - jinja2=3.0.3
+  - markdown=3.3.7
   - markupsafe=2.0.1
   - mkdocs=1.2.3
   - mkdocs-material=8.1.6


### PR DESCRIPTION
- Pinned markdown to 3.3.7 to avoid breaking build

Lightgallery looks for `etree`, which was removed from more recent markdown versions.