### PR TITLE
Add page for reporting errors

### DIFF
--- a/docs/contributing/reporting_errors.md
+++ b/docs/contributing/reporting_errors.md
@@ -1,0 +1,21 @@
+# Reporting Errors
+
+Our documentation is hosted on GitHub at <https://github.com/uabrc/uabrc.github.io>. To report errors, make requests, and contribute to the documentation, you'll need to [Create a GitHub Account](https://github.com/join) if you do not have one already.
+
+## How Do I Report Inaccurate Information?
+
+To report inaccurate information please create an [Inaccuracy Report](https://github.com/uabrc/uabrc.github.io/issues/new?assignees=&labels=fix%3A+inaccuracy&template=inaccuracy_report.yml).
+
+## How Do I Report a Bug?
+
+Bug reports are intended to be issues with page appearance and feature functionality. They are _not_ intended for inaccurate information. See [Report Inaccurate Information] to report inaccuracies.
+
+To report a bug please create a [Bug Report](https://github.com/uabrc/uabrc.github.io/issues/new?assignees=&labels=fix%3A+bug&template=bug_report.yml).
+
+## How Do I Request an Article or Section?
+
+To request an article or section, please create an [Article Request](https://github.com/uabrc/uabrc.github.io/issues/new?assignees=&labels=req%3A+article&template=article_request.yml).
+
+## How Can I Fix It Myself?
+
+To get started creating content, please see our [Contributor Guide](contributor_guide.md). We assume you are already somewhat familiar with Git, GitHub, Markdown, and writing technical information for an educated audience with diverse backgrounds and expertise.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,7 +137,8 @@ nav:
       - Offered Courses: education/courses.md
       - Social Media: education/social_media.md
   - Policies: policies.md
-  - Contributing To The Docs: contributing/contributor_guide.md
+  - Reporting Errors: contributing/reporting_errors.md
+  - Contributing Content: contributing/contributor_guide.md
   - Help:
       - Support: help/support.md
       - FAQ: help/faq.md


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

Add page for reporting errors.

## Proposed Changes

Add a page with sections for:

- Reporting bugs
- Reporting inaccuracies
- Requesting articles
- Points to the contributor guide

Page intro mentions the need for github account.

## Related Issues

Fixes #340 
