### PR TITLE
Add admonition on conda compute nodes

### DIFF
--- a/docs/cheaha/software/software.md
+++ b/docs/cheaha/software/software.md
@@ -27,6 +27,12 @@ Anaconda on Cheaha works like it does on any other system, once the module has b
 <!-- markdownlint-enable MD046 -->
 
 <!-- markdownlint-disable MD046 -->
+!!! important
+
+    Only create environments on compute nodes. Anaconda environment creation consumes substantial resources and should not be run on the login node.
+<!-- markdownlint-enable MD046 -->
+
+<!-- markdownlint-disable MD046 -->
 !!! warning
 
     The Cheaha operating system has a version of Python installed. This version is used by `python` calls when Anaconda has not been loaded.

--- a/docs/workflow_solutions/using_anaconda.md
+++ b/docs/workflow_solutions/using_anaconda.md
@@ -12,6 +12,12 @@ Benefits of Anaconda:
 
 Anaconda can also install Pip and record which Pip packages are installed, so Anaconda can do everything Pip can, and more.
 
+<!-- markdownlint-disable MD046 -->
+!!! important
+
+    If using Anaconda on Cheaha, please see our [Anaconda on Cheaha page](../cheaha/software/software.md#anaconda-on-cheaha) for important details and restrictions.
+<!-- markdownlint-enable MD046 -->
+
 ## What is my best solution for installing Anaconda?
 
 If you are using a local machine or doing general purpose software development, or have a particular package in mind, go [here](#installing-anaconda) to install Anaconda.
@@ -39,6 +45,12 @@ Anaconda is a package manager, meaning it handles all of the difficult mathemati
 Anaconda is structured around environments. Environments are self-contained collections of researcher-selected packages. Environments can be changed out using a simple package without requiring tedious installing and uninstalling of packages or software, and avoiding dependency conflicts with each other. Environments allow researchers to work and collaborate on multiple projects, each with different requirements, all on the same computer. Environments can be installed from the command line, from pre-designed or shared YAML files, and can be modified or updated as needed.
 
 The following subsections detail some of the more common commands and use cases for Anaconda usage. More complete information on this process can be found at the [Anaconda documentation](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#).
+
+<!-- markdownlint-disable MD046 -->
+!!! important
+
+    If using Anaconda on Cheaha, please see our [Anaconda on Cheaha page](../cheaha/software/software.md#anaconda-on-cheaha) for important details and restrictions.
+<!-- markdownlint-enable MD046 -->
 
 ### Create an Environment
 


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

Add admonition about installing conda envs on Cheaha on compute nodes only.

## Proposed Changes

- Add admonition about installing conda envs on Cheaha on compute nodes only.
- Cross-linked general Anaconda page to Cheaha specific page.

## Related Issues

Fixes #368 
