### PR TITLE
Fix tabulate package issue by reverting version

### DIFF
--- a/build_env.yml
+++ b/build_env.yml
@@ -12,6 +12,7 @@ dependencies:
   - mkdocs-table-reader-plugin=1.0.0
   - pip=21.2.4
   - python=3.9.7
+  - tabulate=0.8.9
   - pip:
       - lightgallery==0.5
       - mkdocs-git-revision-date-localized-plugin==1.0.1


### PR DESCRIPTION
Tabulate 0.9.0 breaks build, pinning 0.8.9 until we can get a better fix.
