### PR TITLE
Remove unhelpful construction admonitions

### DIFF
--- a/docs/cheaha/software/software.md
+++ b/docs/cheaha/software/software.md
@@ -1,11 +1,5 @@
 # Software Installation
 
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    This page is a stub and is under construction.
-<!-- markdownlint-enable MD046 -->
-
 ## Anaconda on Cheaha
 
 For additional general information on using Anaconda please see [Anaconda Environments](../../workflow_solutions/using_anaconda.md).
@@ -52,5 +46,3 @@ For more information on usage with examples, see [Anaconda Environments](../../w
 2. Create a new environment with only Mamba using `conda create --name mamba -c conda-forge mamba`
 3. `conda activate mamba`
 4. Use Mamba to install environments as needed. Be aware you must use the flag `--prefix=~/.conda/envs/` to put the environment in the correct location to be seen by Anaconda.
-
-## Open On Demand Sandbox App

--- a/docs/contributing/contributor_guide.md
+++ b/docs/contributing/contributor_guide.md
@@ -2,12 +2,6 @@
 
 We welcome contributions from our community. To ensure a high-quality documentation experience, we have some guidelines for contributors who wish to create.
 
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    This contributor guide is a work in progress and may change and develop over time. Please bear with us, and feel free to offer suggestions.
-<!-- markdownlint-enable MD046 -->
-
 ## Prerequisites
 
 We are using Visual Studio Code (VSCode) for development with the following extensions installed. While VSCode is not required, it can help with automating formatting, linting and Anaconda environment management. VSCode may be obtained from [Visual Studio Code](https://code.visualstudio.com/) and documentation is available at [VSCode: Docs](https://code.visualstudio.com/docs).

--- a/docs/data_management/storage.md
+++ b/docs/data_management/storage.md
@@ -11,12 +11,6 @@
     - To Be Determined: `$USER_SCRATCH` will point to `/scratch/$USER`
 <!-- markdownlint-enable MD046 -->
 
-<!-- markdownlint-disable MD046 -->
-!!! warning
-
-    The information on this page is under construction and some of it may be obsolete. If you need additional clarifications in the meantime, please [contact us](../index.md#contact-us).
-<!-- markdownlint-enable MD046 -->
-
 ## What Type of Storage Do I Need?
 
 There are multiple locations for data storage both on and off Cheaha each with a specific purpose. You can look at the table below to find the storage platform we provide that best matches your needed use-case.

--- a/docs/data_management/transfer/globus.md
+++ b/docs/data_management/transfer/globus.md
@@ -263,7 +263,3 @@ It is NOT RECOMMENDED to make Globus Connect Personal endpoints public as this i
 4. Click "X Delete Endpoint" and a confirmation dialog will open at the top of the page. Respond to the dialog to delete the endpoint, or to cancel.
 
     ![!Delete Endpoint confirmation dialog banner.](./images/globus_105_shared_delete.png)
-
-## Setting up Globus Connect Server
-
-Under construction!

--- a/docs/education/social_media.md
+++ b/docs/education/social_media.md
@@ -1,11 +1,5 @@
 # Social Media
 
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    This page is a stub and is under construction.
-<!-- markdownlint-enable MD046 -->
-
 ## GitHub
 
 <https://github.com/uabrc>

--- a/docs/grants/publications.md
+++ b/docs/grants/publications.md
@@ -13,7 +13,7 @@
 ## Detailed
 
 <!-- markdownlint-disable MD046 -->
-!!! note
+!!! construction
 
     Under construction.
 <!-- markdownlint-enable MD046 -->

--- a/docs/uab_cloud/instance_setup_basic.md
+++ b/docs/uab_cloud/instance_setup_basic.md
@@ -87,12 +87,6 @@ Networks determine how your instance will talk to the internet and other instanc
 
 ### Network Ports Tab
 
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    Under construction
-<!-- markdownlint-enable MD046 -->
-
 1. Leave this tab empty.
 
     ![!Launch Instance dialog. The Network Ports tab is selected. The dialog form has been left empty.](./images/instances_007.png)
@@ -127,44 +121,20 @@ Key Pairs allow individual access rights to the instance via SSH. If you are fol
 
 ### Configuration Tab
 
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    Under construction
-<!-- markdownlint-enable MD046 -->
-
 1. Skip this tab.
 2. Click "Next >" to move to the "Server Groups" tab.
 
 ### Server Groups Tab
-
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    Under construction
-<!-- markdownlint-enable MD046 -->
 
 1. Skip this tab.
 2. Click "Next >" to move to the "Scheduler Hints" tab.
 
 ### Scheduler Hints Tab
 
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    Under construction
-<!-- markdownlint-enable MD046 -->
-
 1. Skip this tab.
 2. Click "Next >" to move to the "Metadata" tab.
 
 ### Metadata Tab
-
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    Under construction
-<!-- markdownlint-enable MD046 -->
 
 1. Skip this tab.
 

--- a/docs/uab_cloud/remote_access.md
+++ b/docs/uab_cloud/remote_access.md
@@ -311,8 +311,4 @@ sftp> get -r <remote_directory> <optional_local_path>
 
 ### RClone
 
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    Under construction.
-<!-- markdownlint-enable MD046 -->
+Please see our [RClone](../data_management/transfer/rclone.md) page for more information on using RClone with the SFTP remote option.

--- a/docs/uab_cloud/snapshots.md
+++ b/docs/uab_cloud/snapshots.md
@@ -58,14 +58,6 @@ To create an instance from an image, follow the directions below, assuming you h
 
 7. Continue following the instructions at [Basic Instance Setup](./instance_setup_basic.md) to start the instance.
 
-### Sharing Instance Snapshots
-
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    Under construction.
-<!-- markdownlint-enable MD046 -->
-
 ### Deleting an Image
 
 To delete an image, return to the "Images" page using the left-hand navigation pane. In the table, find the row with the image you wish to delete, and click the drop-down arrow under "Actions" in that row. Then click "Delete Image" to open a confirmation dialog.
@@ -99,14 +91,6 @@ Volume snapshots are a helpful way to store the state of a volume for later use.
 4. You will be taken to the "Volume Snapshots" page, where your new snapshot will appear in its own row in the table.
 
     ![!volume snapshots page showing new snapshot](./images/create_volume_snapshot_003.png)
-
-### Sharing Volume Snapshots
-
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    Under construction.
-<!-- markdownlint-enable MD046 -->
 
 ### Deleting a Volume Snapshot
 

--- a/docs/workflow_solutions/git.md
+++ b/docs/workflow_solutions/git.md
@@ -1,11 +1,5 @@
 # Git
 
-<!-- markdownlint-disable MD046 -->
-!!! construction
-
-    This page is a stub and is under construction.
-<!-- markdownlint-enable MD046 -->
-
 ## Introductory Guides
 
 Above all else, git is a software and document collaboration tool.


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

See title

## Proposed Changes

Remove admonition:
- cheaha/software.md
- contributing/contributor_guide.md
- education/social_media.md
- uab_cloud/tutorial/instance.md (remove all)
- uab_cloud/snapshots.md (stubs for sharing snapshots)
- workflow_solutions/git.md (overview of git commands)
- data_management/transfer/globus.md (setting up globus server)
- data_management/storage.md

## Related Issues

Related to #417
