### PR TITLE
Update hardware table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
-
-# Created by https://www.toptal.com/developers/gitignore/api/windows,python,macos,linux,visualstudiocode
-# Edit at https://www.toptal.com/developers/gitignore?templates=windows,python,macos,linux,visualstudiocode
+# Created by https://www.toptal.com/developers/gitignore/api/windows,visualstudiocode,python,macos,linux
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,visualstudiocode,python,macos,linux
 
 ### Linux ###
 *~
@@ -46,6 +45,10 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
 
 ### Python ###
 # Byte-compiled / optimized / DLL files
@@ -151,7 +154,15 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
 # Celery stuff
@@ -195,11 +206,21 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
 
 ### VisualStudioCode ###
 .vscode/*
@@ -219,8 +240,6 @@ cython_debug/
 # Ignore all local history of files
 .history
 .ionide
-
-# Support for Project snippet scope
 
 ### Windows ###
 # Windows thumbnail cache files
@@ -248,7 +267,7 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.toptal.com/developers/gitignore/api/windows,python,macos,linux,visualstudiocode
+# End of https://www.toptal.com/developers/gitignore/api/windows,visualstudiocode,python,macos,linux
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 

--- a/docs/cheaha/hardware.md
+++ b/docs/cheaha/hardware.md
@@ -1,6 +1,6 @@
 # Hardware Information
 
-The following hardware summaries may be useful for grant proposal writing. If any information is missing that would be helpful to you, please be sure to [contact us](../index.md#contact-us) or create an issue on our [tracker](https://github.com/uabrc/uabrc.github.io/issues).
+The following hardware summaries may be useful for selecting partitions for workflows and for grant proposal writing. If any information is missing that would be helpful to you, please be sure to [contact us](../index.md#contact-us) or create an issue on our [tracker](https://github.com/uabrc/uabrc.github.io/issues).
 
 <!-- markdownlint-disable MD046 -->
 !!! tip
@@ -10,11 +10,29 @@ The following hardware summaries may be useful for grant proposal writing. If an
 
 ## Cheaha HPC Cluster
 
-The HPC cluster is comprised of 8192 compute cores connected by low-latency Fourteen Data Rate (FDR) and Enhanced Data Rate (EDR) InfiniBand networks. In addition to the basic compute cores, there are also 72 NVIDIA Tesla P100 GPUs available. There is a total of just under 49 TB of memory across the cluster. A description of the available hardware generations are summarized in the following table.
+### Summary
 
-{{ read_csv('cheaha/res/hardware_short_hpc.csv', keep_default_na=False) }}
+The table below contains a summary of the computational resources available on Cheaha and relevant Quality of Service (QoS) Limits. QoS limits allow us to balance usage and ensure fairness for all researchers using the cluster. QoS limits are not a guarantee of resource availability.
 
-The full table can be downloaded [here](./res/hardware_short_hpc.csv).
+In the table, [Slurm](./slurm/introduction.md) partitions are grouped by shared QoS limits on cores, memory, and GPUs. Node limits are applied to partitions independently. All limits are applied to researchers independently.
+
+Examples of how to make use of the table:
+    - You submit 30 jobs to the "express" partition, requesting 10 cores each. If the first 26 jobs start, then 260 out of 264 core limit will be in use. The remaining 4 jobs will be held in queue, because starting one more would go beyond the QoS limit (270 > 264).
+    - You submit 5 jobs to the "medium" partition and 5 to the "long" partition. It is possible that all 10 jobs may start, because partition node limits are separate. If all 5 jobs start, jobs on the "medium" partition.
+    - You submit jobs to the "amperenodes" and "amperenodes-medium" partitions totaling 10 GPUs, and the "pascalnodes" partition totaling 4 GPUs. Jobs totaling 8 or fewer GPUs on the "gpu: ampere" group, and all jobs on "gpu: pascal", can start at the same time.
+
+{{ read_csv('cheaha/res/hardware_summary_cheaha.csv', keep_default_na=False) }}
+<!-- fix headers -->
+
+The full table can be downloaded [here](./res/hardware_summary_cheaha.csv).
+
+### Details
+
+Detailed hardware information, including processor and GPU makes and models, core clock frequencies, and other information for current hardware are in the table below.
+
+{{ read_csv('cheaha/res/hardware_full_all.csv', keep_default_na=False) }}
+
+The full table can be downloaded [here](./res/hardware_full_all.csv).
 
 The table below is a theoretical analysis of FLOPS (floating point operations per second) based on processor instructions and core counts, and is not a reflection of efficiency in practice.
 
@@ -23,20 +41,6 @@ The table below is a theoretical analysis of FLOPS (floating point operations pe
 The full table can be downloaded [here](./res/flops_hpc.csv).
 
 For information on using Cheaha, see our dedicated [section](./getting_started.md).
-
-### Partitions
-
-{{ read_csv('cheaha/res/partitions.csv', keep_default_na=False) }}
-
-The full table can be downloaded [here](./res/partitions.csv).
-
-### Quality of Service (QoS) Limits
-
-Quality of Service (QoS) allows us to balance usage across the cluster, so that no single researcher can consume all of the resources. Each set of QoS limits is applied to one or more partitions according to the table below. Each limit is applied to every researcher on Cheaha. The partitions within a group all share the same limits, so that a researcher can use 1.5 TB on both `express` and `short`, but can't use 2 TB on both at the same time.
-
-{{ read_csv('cheaha/res/qos.csv', keep_default_na=False) }}
-
-The full table can be downloaded [here](./res/qos.csv).
 
 ## Cloud Service at cloud.rc
 
@@ -73,11 +77,3 @@ The table below is a theoretical analysis of FLOPS (floating point operations pe
 {{ read_csv('cheaha/res/flops_container.csv', keep_default_na=False) }}
 
 The full table can be downloaded [here](./res/flops_container.csv).
-
-## Full Hardware Details
-
-Detailed hardware information including processor and GPU makes and models, core clock frequencies, and other information for current hardware are in the table below.
-
-{{ read_csv('cheaha/res/hardware_full_all.csv', keep_default_na=False) }}
-
-The full table can be downloaded [here](./res/hardware_full_all.csv).

--- a/docs/cheaha/hardware.md
+++ b/docs/cheaha/hardware.md
@@ -17,9 +17,10 @@ The table below contains a summary of the computational resources available on C
 In the table, [Slurm](./slurm/introduction.md) partitions are grouped by shared QoS limits on cores, memory, and GPUs. Node limits are applied to partitions independently. All limits are applied to researchers independently.
 
 Examples of how to make use of the table:
-    - You submit 30 jobs to the "express" partition, requesting 10 cores each. If the first 26 jobs start, then 260 out of 264 core limit will be in use. The remaining 4 jobs will be held in queue, because starting one more would go beyond the QoS limit (270 > 264).
-    - You submit 5 jobs to the "medium" partition and 5 to the "long" partition. It is possible that all 10 jobs may start, because partition node limits are separate. If all 5 jobs start, jobs on the "medium" partition.
-    - You submit jobs to the "amperenodes" and "amperenodes-medium" partitions totaling 10 GPUs, and the "pascalnodes" partition totaling 4 GPUs. Jobs totaling 8 or fewer GPUs on the "gpu: ampere" group, and all jobs on "gpu: pascal", can start at the same time.
+
+- You submit 30 jobs to the "express" partition, requesting 10 cores each. If the first 26 jobs start, then 260 out of 264 core limit will be in use. The remaining 4 jobs will be held in queue, because starting one more would go beyond the QoS limit (270 > 264).
+- You submit 5 jobs to the "medium" partition and 5 to the "long" partition. It is possible that all 10 jobs may start, because partition node limits are separate. If all 5 jobs start, jobs on the "medium" partition.
+- You submit jobs to the "amperenodes" and "amperenodes-medium" partitions totaling 10 GPUs, and the "pascalnodes" partition totaling 4 GPUs. Jobs totaling 8 or fewer GPUs on the "gpu: ampere" group, and all jobs on "gpu: pascal", can start at the same time.
 
 {{ read_csv('cheaha/res/hardware_summary_cheaha.csv', keep_default_na=False) }}
 <!-- fix headers -->

--- a/docs/cheaha/hardware.md
+++ b/docs/cheaha/hardware.md
@@ -22,6 +22,12 @@ Examples of how to make use of the table:
 - You submit 5 jobs to the "medium" partition and 5 to the "long" partition. It is possible that all 10 jobs may start, because partition node limits are separate. If all 5 jobs start, jobs on the "medium" partition.
 - You submit jobs to the "amperenodes" and "amperenodes-medium" partitions totaling 10 GPUs, and the "pascalnodes" partition totaling 4 GPUs. Jobs totaling 8 or fewer GPUs on the "gpu: ampere" group, and all jobs on "gpu: pascal", can start at the same time.
 
+<!-- markdownlint-disable MD046 -->
+!!! announcement
+
+    Physical A100 nodes are slated for a future release on Cheaha. Information related to `amperenodes` and the A100 GPUs should be considered tentative information. The `amperenodes` hardware is not yet available as of 2023-08-22. Release date to be determined (TBD).
+<!-- markdownlint-enable MD046 -->
+
 {{ read_csv('cheaha/res/hardware_summary_cheaha.csv', keep_default_na=False) }}
 <!-- fix headers -->
 

--- a/docs/cheaha/res/flops_hpc.csv
+++ b/docs/cheaha/res/flops_hpc.csv
@@ -5,4 +5,5 @@ Generation,Cpu Tflops Per Node,Gpu Tflops Per Node,Tflops Per Node,Nodes,Tflops
 8,0.96,,0.96,4,3.84
 9,2.30,,2.30,52,119.81
 10,4.10,,4.10,34,139.26
-Total,,,,,619.10
+11,5.02,15.14,20.15,20,403.10
+Total,,,,,"1,022.20"

--- a/docs/cheaha/res/hardware_full_all.csv
+++ b/docs/cheaha/res/hardware_full_all.csv
@@ -1,20 +1,21 @@
-Generation,Compute Type,Partition,Total Cores,Total Memory Gb,Total Gpus,Cores Per Node,Cores Per Die,Dies Per Node,Die Brand,Die Name,Die Frequency Ghz,Memory Per Node Gb,Gpu Per Node,Gpu Brand,Gpu Name,Gpu Memory Gb,Nodes
-1,cpu,,128,1024,,2,1,2,AMD,Opteron 242,1.6,16,,,,,64
-2,cpu,,192,1152,,8,4,2,Intel,Xeon E5450,3.0,48,,,,,24
-3,cpu,,384,1536,,12,6,2,Intel,Xeon X5650,2.66,48,,,,,32
-3,cpu,,192,1536,,12,6,2,Intel,Xeon X5650,2.66,96,,,,,16
-4,cpu,,48,1152,,16,8,2,Intel,Xeon X5650,2.7,384,,,,,3
-5,cpu,,192,1152,,16,8,2,Intel,Xeon E2650,2.0,96,,,,,12
-6,cpu,cpu,336,5376,,24,12,2,Intel,Xeon E5-2680 v3,2.5,384,,,,,14
-6,cpu,cpu,912,9728,,24,12,2,Intel,Xeon E5-2680 v3,2.5,256,,,,,38
-6,cpu,cpu,1056,5632,,24,12,2,Intel,Xeon E5-2680 v3,2.5,128,,,,,44
-7,gpu,pascalnodes,504,4608,72,28,14,2,Intel,Xeon E5-2680 v4,2.4,256,4,NVIDIA,Tesla P100,16,18
-8,cpu,cpu,504,4032,,24,12,2,Intel,Xeon E5-2680 v4,2.5,192,,,,,21
-8,high memory,largemem,240,7680,,24,12,2,Intel,Xeon E5-2680 v4,2.5,768,,,,,10
-8,high memory,largemem,96,6144,,24,12,2,Intel,Xeon E5-2680 v4,2.5,1536,,,,,4
-9,cpu,cpu,2496,39936,,48,24,2,Intel,Xeon Gold 6248R,3.0,768,,,,,52
-10,cpu,cpu,4352,17408,,128,64,2,AMD,Epyc 7713 Milan,2.0,512,,,,,34
-1,cpu,,240,960,,48,12,4,Intel,Xeon Gold 6248R,3.0,192,,,,,5
-1,gpu,,512,4096,32,128,64,2,AMD,Epyc 7742 Rome,2.25,1024,8,NVIDIA,A100,40,4
-1,cpu,,144,576,,48,12,4,Intel,Xeon Gold 6248R,3.0,192,,,,,3
-1,gpu,,512,4096,32,128,64,2,AMD,Epyc 7742 Rome,2.25,1024,8,NVIDIA,A100,40,4
+Generation,Compute Type,Total Cores,Total Memory Gb,Total Gpus,Cores Per Node,Cores Per Die,Dies Per Node,Die Brand,Die Name,Die Frequency Ghz,Memory Per Node Gb,Gpu Per Node,Gpu Brand,Gpu Name,Gpu Memory Gb,Nodes
+1,cpu: amd,128,1024,,2,1,2,AMD,Opteron 242,1.6,16,,,,,64
+2,cpu: intel,192,1152,,8,4,2,Intel,Xeon E5450,3.0,48,,,,,24
+3,cpu: intel,384,1536,,12,6,2,Intel,Xeon X5650,2.66,48,,,,,32
+3,cpu: intel,192,1536,,12,6,2,Intel,Xeon X5650,2.66,96,,,,,16
+4,cpu: intel,48,1152,,16,8,2,Intel,Xeon X5650,2.7,384,,,,,3
+5,cpu: intel,192,1152,,16,8,2,Intel,Xeon E2650,2.0,96,,,,,12
+6,cpu: intel,336,5376,,24,12,2,Intel,Xeon E5-2680 v3,2.5,384,,,,,14
+6,cpu: intel,912,9728,,24,12,2,Intel,Xeon E5-2680 v3,2.5,256,,,,,38
+6,cpu: intel,1056,5632,,24,12,2,Intel,Xeon E5-2680 v3,2.5,128,,,,,44
+7,gpu: pascal,504,4608,72,28,14,2,Intel,Xeon E5-2680 v4,2.4,256,4,NVIDIA,Tesla P100,16,18
+8,cpu: intel,504,4032,,24,12,2,Intel,Xeon E5-2680 v4,2.5,192,,,,,21
+8,mem: large,240,7680,,24,12,2,Intel,Xeon E5-2680 v4,2.5,768,,,,,10
+8,mem: large,96,6144,,24,12,2,Intel,Xeon E5-2680 v4,2.5,1536,,,,,4
+9,cpu: intel,2496,39936,,48,24,2,Intel,Xeon Gold 6248R,3.0,768,,,,,52
+10,cpu: amd,4352,17408,,128,64,2,AMD,Epyc 7713 Milan,2.0,512,,,,,34
+11,gpu: ampere,2560,10240,40,128,64,2,AMD,Epyc 7763 Milan,2.45,512,2,NVIDIA,A100,80,20
+1,cpu: intel,240,960,,48,12,4,Intel,Xeon Gold 6248R,3.0,192,,,,,5
+1,gpu: ampere,512,4096,32,128,64,2,AMD,Epyc 7742 Rome,2.25,1024,8,NVIDIA,A100,40,4
+1,cpu: intel,144,576,,48,12,4,Intel,Xeon Gold 6248R,3.0,192,,,,,3
+1,gpu: ampere,512,4096,32,128,64,2,AMD,Epyc 7742 Rome,2.25,1024,8,NVIDIA,A100,40,4

--- a/docs/cheaha/res/hardware_summary_cheaha.csv
+++ b/docs/cheaha/res/hardware_summary_cheaha.csv
@@ -1,0 +1,21 @@
+Partition,Time Limit in Hours,Nodes (Limit/Partition),Cores/Node (Limit/Person),Mem GB/Node (Limit/Person),GPU/Node (Limit/Person)
+**cpu: amd**,,,,,
+amd-hdr100,150,34 (5),128 (264),504 (3072),
+,,,,,
+**cpu: intel**,,,,,
+express,2,51 (~),48 (264),754 (3072),
+short,12,51 (44),48 (264),754 (3072),
+medium,50,51 (44),48 (264),754 (3072),
+long,150,51 (5),48 (264),754 (3072),
+,,,,,
+**gpu: ampere**
+amperenodes,12,20 (TBD),32 (64),189 (384),2 (4)
+amperenodes-medium,48,20 (TBD),32 (64),189 (384),2 (4)
+,,,,,
+**gpu: pascal**,,,,,
+pascalnodes,12,18 (~),28 (56),252 (500),4 (8)
+pascalnodes-medium,48,7 (~),28 (56),252 (500),4 (8)
+,,,,,
+**mem: large**
+largemem,50,13 (10),24 (290),755 (7168),
+largemem-long,150,5 (10),24 (290),755 (7168),


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

<!-- Briefly summarize the proposed changes -->

Provides a manually curated table produced by scripts from here: https://github.com/wwarriner/slurm_status_tools, running on Cheaha and interacting with the manually curated hardware information table here: https://gitlab.rc.uab.edu/rc-data-science/metrics/rc-hardware.

Currently, there is not a method to link the two data sets together automatically. The manually curated hardware table is unaware of partitions, and the info coming from `scontrol` and `sacctmgr` aren't aware of the hardware details.

Any automated solution is beyond the scope of the docs, but will be proposed and followed through outside of the docs scope.

What I will do is prepare information on how I built the table and place it in the contributor guide, in a separate issue.

## Proposed Changes

<!-- Provide specific details of what is changing -->

- Change structure of hardware table
- Update hardware table data
- Modify text to fit the new table format
- Remove superfluous text
- Provide examples of how quotas work

## Related Issues

Related to #501
Fixes #480
Fixes #353

- 480 is resolved because all fields are reflected except Priority Tier. I don't want to advertise this one because it adds noise, and the priority and partition systems need to be re-engineered.
- 353 is resolved because the memory reflected in the table is the actual values reported by Slurm in the "RealMem" field of `scontrol`.

## Future work

Future #501 for general hardware page(s) improvements
Future #592 for table improvements
