### PR TITLE
Adding UAB AI official page in training resources

### DIFF
--- a/docs/education/training_resources.md
+++ b/docs/education/training_resources.md
@@ -2,6 +2,7 @@
 
 ## Internal Resources
 
+- [AI at UAB](https://www.uab.edu/ai/): AI-related resources, available to UAB Employees and the broader community, encompassing safety protocols, ethical principles, and diverse applications of AI, including current trends.
 - [Informatics Club](https://uab.campuslabs.com/engage/organization/informaticsclub): A UAB group for students and trainees to learn more about informatics.
     - [Code, Chat & Collab](https://calendar.uab.edu/event/code_chat_collab_5718): A recurring meet-up hosted by the Informatics Club where students, staff and faculty can meet to discuss informatics, data analysis, software development, and Cheaha use.
     - [Events and Resources](https://lnk.bio/5nl5): A collection of useful resources provided by the Informatics club.


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview
Adding the UAB AI official page under training resources
<!-- Briefly summarize the proposed changes -->

## Proposed Changes
Just adding the UAB AI official page link and short description about it.
<!-- Provide specific details of what is changing -->

## Related Issues
Fixes #686 
<!--
Examples:
Fixes #123
Related to #101
-->
