### PR TITLE
Adding instructions and login credentials information on XIAS pages

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,4 +2,5 @@
     "MD007": { "indent": 4 },
     "MD013": false,
     "MD046": { "style": "fenced" }
+    "MD036": { "style": "fenced" }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,4 @@
     "MD007": { "indent": 4 },
     "MD013": false,
     "MD046": { "style": "fenced" }
-    "MD036": { "style": "fenced" }
 }

--- a/docs/account_management/xias/index.md
+++ b/docs/account_management/xias/index.md
@@ -15,11 +15,12 @@ An overview of creating an external collaborator account:
 
 To login to the Cheaha and gitlab services, you need to use your XIAS email address and a password  used to create the XIAS account as credentials. For accessing the cloud service, your username is your XIAS email address, while the password can be any current password you have, not necessarily the same as the one used to create your XIAS email address. For further guidance on how to proceed and what steps to take next, please refer to the following documentation pages.
 
-<!-- markdownlint-disable MD046 -->
+<!-- markdownlint-disable MD046-->
 !!! warning
 
-  Before proceeding with any of the resources below, be sure you have been granted authorization to those particular resources by your Sponsor.
+    Before proceeding with any of the resources below, be sure you have been granted authorization to those particular resources by your Sponsor.
 <!-- markdownlint-enable MD046 -->
+
 - [How do I create a Cheaha account?](../cheaha_account.md)
 - [How do I get access to GitLab?](../gitlab_account.md)
 - [How do I get access to OpenStack?](../../uab_cloud/tutorial/index.md)

--- a/docs/account_management/xias/index.md
+++ b/docs/account_management/xias/index.md
@@ -16,8 +16,9 @@ We recommend the sponsor and guest stay in close contact during the process in c
 ## What is next and how to login to services?
 
 To login to the [Cheaha](../../cheaha/getting_started.md) and [GitLab](../gitlab_account.md) services, you need to use your XIAS email address and the password used to create your XIAS account. To access the Cloud.rc, you first need to request an account. Please follow [Cloud.rc](../../uab_cloud/index.md#first-steps) to initiate the request.
- <!-- your username is your XIAS email address, while the password can be any current password you have, not necessarily the same as the one used to create your XIAS email address. -->
- For further guidance on how to proceed and what steps to take next, please refer to the following documentation pages.
+
+For further guidance on how to proceed and what steps to take next, please refer to the following documentation pages.
+
 <!-- markdownlint-disable MD046-->
 !!! warning
 
@@ -26,4 +27,5 @@ To login to the [Cheaha](../../cheaha/getting_started.md) and [GitLab](../gitlab
 
 - [How do I create a Cheaha account?](../cheaha_account.md)
 - [How do I get access to GitLab?](../gitlab_account.md)
-- [How do I get access to OpenStack?](../../uab_cloud/tutorial/index.md)
+- [How do I get access to Cloud.rc (OpenStack)?](../../uab_cloud/tutorial/index.md)
+  

--- a/docs/account_management/xias/index.md
+++ b/docs/account_management/xias/index.md
@@ -11,10 +11,13 @@ An overview of creating an external collaborator account:
     2. [Create and manage XIAS Guests](pi_guest_management.md)
 2. The guest must then [Create a XIAS Guest Account](guest_instructions.md)
 
+We recommend the sponsor and guest stay in close contact during the process in case anything unexpected occurs. If you encounter difficulties with any part of the XIAS website process, please contact [AskIT](mailto:askit@uab.edu). If you encounter difficulties with the Cheaha account creation portion at the Open OnDemand web portal, please contact [Support](../../help/support.md)
+
 ## What is next and how to login to services?
 
-To login to the Cheaha and gitlab services, you need to use your XIAS email address and a password  used to create the XIAS account as credentials. For accessing the cloud service, your username is your XIAS email address, while the password can be any current password you have, not necessarily the same as the one used to create your XIAS email address. For further guidance on how to proceed and what steps to take next, please refer to the following documentation pages.
-
+To login to the [Cheaha](../../cheaha/getting_started.md) and [GitLab](../gitlab_account.md) services, you need to use your XIAS email address and the password used to create your XIAS account. To access the Cloud.rc, you first need to request an account. Please follow [Cloud.rc](../../uab_cloud/index.md#first-steps) to initiate the request.
+ <!-- your username is your XIAS email address, while the password can be any current password you have, not necessarily the same as the one used to create your XIAS email address. -->
+ For further guidance on how to proceed and what steps to take next, please refer to the following documentation pages.
 <!-- markdownlint-disable MD046-->
 !!! warning
 
@@ -24,5 +27,3 @@ To login to the Cheaha and gitlab services, you need to use your XIAS email addr
 - [How do I create a Cheaha account?](../cheaha_account.md)
 - [How do I get access to GitLab?](../gitlab_account.md)
 - [How do I get access to OpenStack?](../../uab_cloud/tutorial/index.md)
-
-We recommend the sponsor and guest stay in close contact during the process in case anything unexpected occurs. If you encounter difficulties with any part of the XIAS website process, please contact [AskIT](mailto:askit@uab.edu). If you encounter difficulties with the Cheaha account creation portion at the Open OnDemand web portal, please contact [Support](../../help/support.md)

--- a/docs/account_management/xias/index.md
+++ b/docs/account_management/xias/index.md
@@ -11,4 +11,17 @@ An overview of creating an external collaborator account:
     2. [Create and manage XIAS Guests](pi_guest_management.md)
 2. The guest must then [Create a XIAS Guest Account](guest_instructions.md)
 
+## What is next and how to login to services?
+
+To login to the Cheaha and gitlab services, you need to use your XIAS email address and a password  used to create the XIAS account as credentials. For accessing the cloud service, your username is your XIAS email address, while the password can be any current password you have, not necessarily the same as the one used to create your XIAS email address. For further guidance on how to proceed and what steps to take next, please refer to the following documentation pages.
+
+<!-- markdownlint-disable MD046 -->
+!!! warning
+
+  Before proceeding with any of the resources below, be sure you have been granted authorization to those particular resources by your Sponsor.
+<!-- markdownlint-enable MD046 -->
+- [How do I create a Cheaha account?](../cheaha_account.md)
+- [How do I get access to GitLab?](../gitlab_account.md)
+- [How do I get access to OpenStack?](../../uab_cloud/tutorial/index.md)
+
 We recommend the sponsor and guest stay in close contact during the process in case anything unexpected occurs. If you encounter difficulties with any part of the XIAS website process, please contact [AskIT](mailto:askit@uab.edu). If you encounter difficulties with the Cheaha account creation portion at the Open OnDemand web portal, please contact [Support](../../help/support.md)


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview
Adding instructions (e.g where to to go next?) and login credentials information for XIAS user
<!-- Briefly summarize the proposed changes -->

## Proposed Changes
- Add links for next steps, such as where to go to create a Cheaha account, how to get access to GitLab and OpenStack services in [AIXS index page](https://docs.rc.uab.edu/account_management/xias/) 
- Adding information about login credentials information for XIAS users
<!-- Provide specific details of what is changing -->

## Related Issues
Fixes #547 
Fixes #668 
<!--
Examples:
Fixes #123
Related to #101
-->
