### PR TITLE
Adding notes on the practice of using `module reset`

### DIFF
--- a/docs/cheaha/open_ondemand/ood_layout.md
+++ b/docs/cheaha/open_ondemand/ood_layout.md
@@ -102,6 +102,12 @@ In addition to requesting general resources, for some apps you will have the opt
 
 For jobs such as RStudio and Jupyter, some modules like CUDA need to be loaded beforehand so the application has access to it. This can also include loading compiler modules such as CMake and GCC for compiling package installations or editing your `$PATH` specifically for the interactive app without needing to edit your `.bashrc`. See the software specific pages for more examples on how to use the Environment Setup.
 
+<!-- markdownlint-disable MD046 -->
+!!! Note
+
+    In the OOD session, the module is automatically reset at the beginning of every session by default. Therefore, avoid using `module reset` in the 'Environment Setup' box. See [best practice for loading modules](../software/modules.md/#best-practice-for-loading-modules) for more information.
+<!-- markdownlint-disable MD046 -->
+
 ### My Interactive Sessions
 
 The My Interactive Sessions page lists the available apps and your current interactive sessions. If you are logged out, disconnected, or lose track of an interactive application (because of a closed tab or computer shutdown) you can reconnect to running applications on this page. The My Interactive Sessions page looks like:

--- a/docs/cheaha/slurm/gpu.md
+++ b/docs/cheaha/slurm/gpu.md
@@ -111,6 +111,12 @@ For versions of PyTorch 1.13 and newer, use the following template instead.
 - CPU Version: `conda install pytorch==... torchvision==... cpuonly -c pytorch`
 - GPU Version: `conda install pytorch==... torchvision==... pytorch-cuda=... -c pytorch -c nvidia`
 
+<!-- markdownlint-disable MD046 -->
+!!! Note
+
+     When loading modules, such as CUDA modules for jobs requiring one or more GPUs, always utilize `module reset` before loading modules, both at the terminal and within `sbatch` scripts. See [best practice for loading modules](../software/modules.md/#best-practice-for-loading-modules) for more information.
+<!-- markdownlint-disable MD046 -->
+
 ## Reviewing GPU Jobs
 
 As with all jobs, use [`sacct`](job_management.md#reviewing-past-jobs-with-sacct) to review GPU jobs. Quantity of GPUs may be reviewed using the `reqtres` and `alloctres` [fields](job_management.md#sacct-fields).

--- a/docs/cheaha/slurm/practical_sbatch.md
+++ b/docs/cheaha/slurm/practical_sbatch.md
@@ -196,6 +196,12 @@ sbatch --array=0-$FILE_COUNT job.sh
 
 To use the script, enter the command `bash main.sh` at the terminal.
 
+<!-- markdownlint-disable MD046 -->
+!!! Note
+
+    When writing `sbatch` scripts for job submission and managing modules, begin your script by resetting the module environment with `module reset` to ensure a clean environment for subsequent configurations. See [best practice for loading modules](../software/modules.md/#best-practice-for-loading-modules) for more information.
+<!-- markdownlint-enable MD046 -->
+
 ## Putting it All Together
 
 We needed three parts to make the `sbatch --array` job work for our task. Each of these parts has been described above in some detail.

--- a/docs/cheaha/slurm/submitting_jobs.md
+++ b/docs/cheaha/slurm/submitting_jobs.md
@@ -65,7 +65,7 @@ For batch jobs, flags are typically included as directive comments at the top of
 
 Below is an example batch job script. To test it, copy and paste it into a plain text file `testjob.sh` in your [Home Directory](../../data_management/storage.md#home-directory) on Cheaha. Run it at the terminal by navigating to your home directory by entering `cd ~` and then entering `sbatch testjob.sh`. Momentarily, two text files with `.out` and `.err` suffixes will be produced in your home directory.
 
-``` bash
+```py linenums="1"
 #!/bin/bash
 #
 #SBATCH --job-name=test
@@ -102,7 +102,7 @@ Building on the job script above, below is an array job. Array jobs are useful w
 
 To test the script below, copy and paste it into a plain text file `testarrayjob.sh` in your [Home Directory](../../data_management/storage.md#home-directory) on Cheaha. Run it at the terminal by navigating to your home directory by entering `cd ~` and then entering `sbatch testarrayjob.sh`. Momentarily, 16 text files with `.out` and `.err` suffixes will be produced in your home directory.
 
-``` bash
+```py linenums="1"
 #!/bin/bash
 #
 #SBATCH --job-name=test
@@ -232,6 +232,10 @@ Alternatively, `srun` can also run MPI, OpenMP, hybrid MPI/OpenMP, and many more
 
     Instead of `srun`, please load one of the `OpenMPI` modules with an appropriate version. Please contact [Support](../../help/support.md) with any questions or concerns.
 <!-- markdownlint-enable MD046 -->
+
+## Environment Setup and Module Usage in Job Submission
+
+Before submitting a job using `sbatch`, it's crucial to establish a tailored environment, including software installations and  loading necessary modules containing the required software packages. We highly recommend the practice of putting `module reset` before any `module load` calls in job scripts. The module system modifies the environment whenever the module list changes, and Slurm jobs inherit the environment from whatever called `sbatch` or `srun`. The module reset command normalizes the initial environment for the script, improving repeatability and minimizing the risk of hard-to-diagnose module conflicts. For examples and further information, please see [best practice for loading modules](../software/modules.md/#best-practice-for-loading-modules).
 
 ## Graphical Interactive Jobs
 

--- a/docs/cheaha/slurm/submitting_jobs.md
+++ b/docs/cheaha/slurm/submitting_jobs.md
@@ -65,7 +65,7 @@ For batch jobs, flags are typically included as directive comments at the top of
 
 Below is an example batch job script. To test it, copy and paste it into a plain text file `testjob.sh` in your [Home Directory](../../data_management/storage.md#home-directory) on Cheaha. Run it at the terminal by navigating to your home directory by entering `cd ~` and then entering `sbatch testjob.sh`. Momentarily, two text files with `.out` and `.err` suffixes will be produced in your home directory.
 
-```bash
+```bash linenums="1"
 #!/bin/bash
 #
 #SBATCH --job-name=test
@@ -102,7 +102,7 @@ Building on the job script above, below is an array job. Array jobs are useful w
 
 To test the script below, copy and paste it into a plain text file `testarrayjob.sh` in your [Home Directory](../../data_management/storage.md#home-directory) on Cheaha. Run it at the terminal by navigating to your home directory by entering `cd ~` and then entering `sbatch testarrayjob.sh`. Momentarily, 16 text files with `.out` and `.err` suffixes will be produced in your home directory.
 
-```bash
+```bash linenums="1"
 #!/bin/bash
 #
 #SBATCH --job-name=test

--- a/docs/cheaha/slurm/submitting_jobs.md
+++ b/docs/cheaha/slurm/submitting_jobs.md
@@ -65,7 +65,7 @@ For batch jobs, flags are typically included as directive comments at the top of
 
 Below is an example batch job script. To test it, copy and paste it into a plain text file `testjob.sh` in your [Home Directory](../../data_management/storage.md#home-directory) on Cheaha. Run it at the terminal by navigating to your home directory by entering `cd ~` and then entering `sbatch testjob.sh`. Momentarily, two text files with `.out` and `.err` suffixes will be produced in your home directory.
 
-```py linenums="1"
+```bash
 #!/bin/bash
 #
 #SBATCH --job-name=test
@@ -102,7 +102,7 @@ Building on the job script above, below is an array job. Array jobs are useful w
 
 To test the script below, copy and paste it into a plain text file `testarrayjob.sh` in your [Home Directory](../../data_management/storage.md#home-directory) on Cheaha. Run it at the terminal by navigating to your home directory by entering `cd ~` and then entering `sbatch testarrayjob.sh`. Momentarily, 16 text files with `.out` and `.err` suffixes will be produced in your home directory.
 
-```py linenums="1"
+```bash
 #!/bin/bash
 #
 #SBATCH --job-name=test
@@ -235,7 +235,7 @@ Alternatively, `srun` can also run MPI, OpenMP, hybrid MPI/OpenMP, and many more
 
 ## Environment Setup and Module Usage in Job Submission
 
-Before submitting a job using `sbatch`, it's crucial to establish a tailored environment, including software installations and  loading necessary modules containing the required software packages. We highly recommend the practice of putting `module reset` before any `module load` calls in job scripts. The module system modifies the environment whenever the module list changes, and Slurm jobs inherit the environment from whatever called `sbatch` or `srun`. The module reset command normalizes the initial environment for the script, improving repeatability and minimizing the risk of hard-to-diagnose module conflicts. For examples and further information, please see [best practice for loading modules](../software/modules.md/#best-practice-for-loading-modules).
+Before submitting a job using `sbatch`, it's crucial to establish a tailored environment, including software installations and loading necessary modules containing the required software packages. We highly recommend the practice of putting `module reset` before any `module load` calls in job scripts. The module system modifies the environment whenever the module list changes, and Slurm jobs inherit the environment from whatever called `sbatch` or `srun`. The module reset command normalizes the initial environment for the script, improving repeatability and minimizing the risk of hard-to-diagnose module conflicts. For examples and further information, please see [best practice for loading modules](../software/modules.md/#best-practice-for-loading-modules).
 
 ## Graphical Interactive Jobs
 

--- a/docs/cheaha/software/modules.md
+++ b/docs/cheaha/software/modules.md
@@ -143,7 +143,17 @@ To reduce unexpected behavior and/or to get rid of Lmod errors,
     TopHat/2.1.1-foss-2016a
     ```
 
-2. Before loading modules in a shell/bash/sbatch script, use a clean shell by using `module reset` at the beginning to restore to default system settings. Using `module reset` before loading modules separates what software is loaded in the working shell from the software loaded in the script shell. Be aware that forked processes (like scripts) and Slurm commands inherit the environment variables of the working shell, including loaded modules. Here is an example that shows module conflict between cuda11.8 and cuda11.4 versions that may lead to unexpected behavior or an erroneous output.
+2. Before loading modules in a shell/bash/sbatch script, use a clean shell by using `module reset` at the beginning.
+      - What it causes to happen
+         - Clearing loaded modules.
+         - Loading default modules specified by the system administrator.
+      - What it prevents from happening
+          - Module conflicts.
+      - Why it is a best-practice
+          - Ensures reproducibility by starting with a clean environment.
+          - Manages software dependencies effectively.
+
+Using `module reset` before loading modules separates what software is loaded in the working shell from the software loaded in the script shell. Be aware that forked processes (like scripts) and Slurm commands inherit the environment variables of the working shell, including loaded modules. Here is an example that shows module conflict between cuda11.8 and cuda11.4 versions that may lead to unexpected behavior or an erroneous output.
 
 ```bash
 # Working shell where you may try testing module load and your run script

--- a/docs/cheaha/software/modules.md
+++ b/docs/cheaha/software/modules.md
@@ -99,7 +99,7 @@ module savelist
 
 ## Best Practice for Loading Modules
 
-To reduce unexpected behavior and/or to get rid of Lmod errors,
+When using modules in Cheaha, we recommend users to follow these best practices to avoid any potential module conflicts, reduce unexpected behavior and/or to get rid of Lmod errors:
 
 1. Avoid using `module load` in `$HOME/.bashrc`. Instead, create a bash script with the module load commands and source it each time to load the modules needed in a shell/[sbatch script](../slurm/submitting_jobs.md). Here is an example of loading module in a bash script named `module_test.sh` and compilation,
 
@@ -143,16 +143,17 @@ To reduce unexpected behavior and/or to get rid of Lmod errors,
     TopHat/2.1.1-foss-2016a
     ```
 
-2. Before loading modules in a shell/bash/sbatch script, use a clean shell by using `module reset` at the beginning.
-      - What it causes to happen
+2. Be selective and only load a specific module version that you need for your current workflow.Loading unnecessary modules can lead to conflicts and inefficiencies.
+3. Before loading modules in a shell/bash/sbatch script, use a clean shell by using `module reset` at the beginning.
+      - What it does:
          - Clearing loaded modules.
          - Loading default modules specified by the system administrator.
-      - What it prevents from happening
+      - What it prevents from happening:
           - Module conflicts.
-      - Why it is a best-practice
+      - Why it is a best-practice:
           - Ensures reproducibility by starting with a clean environment.
           - Manages software dependencies effectively.
-
+  
 Using `module reset` before loading modules separates what software is loaded in the working shell from the software loaded in the script shell. Be aware that forked processes (like scripts) and Slurm commands inherit the environment variables of the working shell, including loaded modules. Here is an example that shows module conflict between cuda11.8 and cuda11.4 versions that may lead to unexpected behavior or an erroneous output.
 
 ```bash

--- a/docs/cheaha/software/modules.md
+++ b/docs/cheaha/software/modules.md
@@ -143,7 +143,7 @@ When using modules in Cheaha, we recommend users to follow these best practices 
     TopHat/2.1.1-foss-2016a
     ```
 
-2. Be selective and only load a specific module version that you need for your current workflow.Loading unnecessary modules can lead to conflicts and inefficiencies.
+2. Be selective and only load a specific module version that you need for your current workflow. Loading unnecessary modules can lead to conflicts and inefficiencies.
 3. Before loading modules in a shell/bash/sbatch script, use a clean shell by using `module reset` at the beginning.
       - What it does:
          - Clearing loaded modules.


### PR DESCRIPTION
<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview
Notes on the practice of using `module reset` command at the start of sbatch scripts.
<!-- Briefly summarize the proposed changes -->

## Proposed Changes
- Adding notes on the practice of `module reset' in [modules and applications](https://docs.rc.uab.edu/cheaha/software/modules/) page.
- crosslink at: [Job submission](https://docs.rc.uab.edu/cheaha/slurm/submitting_jobs/), [Practical sbatch](https://docs.rc.uab.edu/cheaha/slurm/practical_sbatch/),  [GPU](https://docs.rc.uab.edu/cheaha/slurm/gpu/#scheduling-gpus),  and [OOD](https://docs.rc.uab.edu/cheaha/open_ondemand/ood_layout/) pages.
<!-- Provide specific details of what is changing -->

## Related Issues
Fixes #524 
<!--
Examples:
Related to #101
-->

