### PR TITLE
Rearranged conda content specific to platforms

### DIFF
--- a/docs/cheaha/software/software.md
+++ b/docs/cheaha/software/software.md
@@ -46,11 +46,7 @@ Anaconda on Cheaha works like it does on any other system, once the module has b
     If the Anaconda software instructs you to use `conda init` while on Cheaha, please ignore it to avoid future issues with [Open OnDemand](../open_ondemand/index.md).
 <!-- markdownlint-disable MD046 -->
 
-For more information on usage with examples, see [Anaconda Environments](../../workflow_solutions/using_anaconda.md).
-
-### Speedups Using Mamba
-
-Use of Mamba has been deprecated on Cheaha. On Cheaha, use `module load Anaconda3` and the usual `conda` commands instead. The backend of `conda` has been set to use `libmamba` and is now equally performant.
+For more information on usage with examples, see [Anaconda Environments](../../workflow_solutions/using_anaconda.md). Need some hands-on experience, you can find instructions on how to install PyTorch and TensorFlow using Anaconda in this [tutorial](../cheaha/tutorial/pytorch_tensorflow.md).
 
 ## Singularity Containers
 

--- a/docs/uab_cloud/installing_software.md
+++ b/docs/uab_cloud/installing_software.md
@@ -139,17 +139,11 @@ Below are a few examples of installing certain common softwares that may be usef
 
 #### Installing Miniconda
 
-We recommend installing [Miniconda](https://docs.conda.io/en/latest/miniconda.html) on cloud.rc instances, as opposed to Anaconda, to conserve storage space.
+Miniconda is a lightweight version of Anaconda. While Anaconda's base environment comes with Python, the Scipy stack, and other common packages pre-installed, Miniconda comes with no packages installed. This is an excellent alternative to the full Anaconda installation for environments where minimal space is available or where setup time is important. We recommend installing [Miniconda](https://docs.conda.io/en/latest/miniconda.html) on cloud.rc instances, as opposed to Anaconda, to conserve storage space. For more information on how to use Anaconda see the [Using Anaconda](../workflow_solutions/using_anaconda.md#using-anaconda). Need some hands-on experience, you can find instructions on how to install PyTorch and TensorFlow using Anaconda in this [tutorial](../cheaha/tutorial/pytorch_tensorflow.md).
 
 1. Run the commands in [Before Installing Software](#before-installing-software).
 2. `wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh`
 3. `bash Miniconda3-latest-Linux-x86_64.sh`
-
-<!-- markdownlint-disable MD046 -->
-!!! tip
-
-    Consider installing [Mamba](../workflow_solutions/using_anaconda.md#mamba) to speed up environment installation.
-<!-- markdownlint-enable MD046 -->
 
 #### Installing Singularity
 

--- a/docs/workflow_solutions/using_anaconda.md
+++ b/docs/workflow_solutions/using_anaconda.md
@@ -18,37 +18,13 @@ Anaconda can also install Pip and record which Pip packages are installed, so An
     If using Anaconda on Cheaha, please see our [Anaconda on Cheaha page](../cheaha/software/software.md#anaconda-on-cheaha) for important details and restrictions.
 <!-- markdownlint-enable MD046 -->
 
-## What is my best solution for installing Anaconda?
-
-If you are using a local machine or doing general purpose software development, or have a particular package in mind, go [here](#installing-anaconda) to install Anaconda.
-
-If you are using a virtual machine or container, go [here](#installing-miniconda) to install Miniconda.
-
-If you are using Cheaha, go [here](../cheaha/software/software.md#anaconda-on-cheaha) for how to use Anaconda on Cheaha.
-
-### Installing Anaconda
-
-The full Anaconda install is a good choice if you are using a local machine, or doing general Python development work, or have a particular scientific package in mind.
-
-Anaconda installation instructions are located here: <https://docs.anaconda.com/anaconda/install/index.html>.
-
-For best performance, be sure to set the default solver to `libmamba` using `conda config --set solver libmamba`. For more information see: <https://conda.github.io/conda-libmamba-solver/getting-started/#set-as-default>.
-
-### Installing Miniconda
-
-Miniconda is a lightweight version of Anaconda. While Anaconda's base environment comes with Python, the Scipy stack, and other common packages pre-installed, Miniconda comes with no packages installed. This is an excellent alternative to the full Anaconda installation for environments where minimal space is available or where setup time is important, like [virtual machines](../uab_cloud/index.md) and [containers](getting_containers.md).
-
-Miniconda installation instructions are located here: <https://docs.conda.io/en/latest/miniconda.html>.
-
-For best performance, be sure to set the default solver to `libmamba` using `conda config --set solver libmamba`. For more information see: <https://conda.github.io/conda-libmamba-solver/getting-started/#set-as-default>.
-
 ## Using Anaconda
 
 Anaconda is a package manager, meaning it handles all of the difficult mathematics and logistics of figuring out exactly what versions of which packages should be downloaded to meet your needs, or inform you if there is a conflict.
 
 Anaconda is structured around environments. Environments are self-contained collections of researcher-selected packages. Environments can be changed out using a simple package without requiring tedious installing and uninstalling of packages or software, and avoiding dependency conflicts with each other. Environments allow researchers to work and collaborate on multiple projects, each with different requirements, all on the same computer. Environments can be installed from the command line, from pre-designed or shared YAML files, and can be modified or updated as needed.
 
-The following subsections detail some of the more common commands and use cases for Anaconda usage. More complete information on this process can be found at the [Anaconda documentation](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#).
+The following subsections detail some of the more common commands and use cases for Anaconda usage. More complete information on this process can be found at the [Anaconda documentation](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#). Need some hands-on experience, you can find instructions on how to install PyTorch and TensorFlow using Anaconda in this [tutorial](../cheaha/tutorial/pytorch_tensorflow.md).
 
 <!-- markdownlint-disable MD046 -->
 !!! important
@@ -311,9 +287,3 @@ Now we can be sure that the correct versions of the software will be installed o
 Building on the example above, we can bring in good software development practices to ensure we don't lose track of how our environment is changing as we develop our software or our workflows. If you've ever lost a lot of hard work by accidentally deleting an important file, or forgetting what changes you've made that need to be rolled back, this section is for you.
 
 Efficient software developers live the mantra "Don't repeat yourself". Part of not repeating yourself is keeping a detailed and meticulous record of changes made as your software grows over time. [Git](git_collaboration.md) is a way to have the computer keep track of those changes digitally. Git can be used to save changes to environment files as they change over time. Remember that each time your environment changes to commit the output of [Exporting your Environment](#exporting-an-environment) to a repository for your project.
-
-## Speeding Things up with Mamba
-
-Use of Mamba has been deprecated on Cheaha. On Cheaha, use `module load Anaconda3` and the usual `conda` commands instead. The backend of `conda` has been set to use `libmamba` and is now equally performant.
-
-If you are using Mamba on a local machine and have Anaconda installed, you can set `libmamba` as your default solver using `conda config --set solver libmamba` as described here: <https://conda.github.io/conda-libmamba-solver/getting-started/#set-as-default>


### PR DESCRIPTION
# Pull Request

## Overview

This pull request addresses the arrangement of content of Anaconda content on the docs, across multiple platforms (Cheaha, rc cloud).

## Proposed Changes

1. Moved this: https://docs.rc.uab.edu/workflow_solutions/using_anaconda/#what-is-my-best-solution-for-installing-anaconda to here: https://docs.rc.uab.edu/uab_cloud/installing_software/#installing-software

2. Removed all info on libmamba as it relates to Anaconda.

3. Added crosslinks for "how to use Anaconda" on Tutorial page for PyTorch and TensorFlow. Did the same on the tutorial page.

## Related Issues

Fixes #681 
Related to #567 
