### PR TITLE
Updates to LTS Page: s3cmd and s5cmd installation

### DIFF
--- a/docs/data_management/lts/interfaces.md
+++ b/docs/data_management/lts/interfaces.md
@@ -1,3 +1,7 @@
+---
+toc_depth: 3
+---
+
 # Connecting to LTS
 
 LTS is not available as a mounted filesystem on local computers or Cheaha. You must use an interface to transfer data between LTS and whichever machine you are using. There are a variety of interfaces with the following recommendations.
@@ -40,7 +44,7 @@ conda activate s3
 pip install s3cmd
 ```
 
-Please note that the instructions mentioned above are specific to the Cheaha system. If you need to transfer data between your personal computer and LTS, you'll need to install `s3cmd` and `s5cmd` on your machine. Please refer to this [section](#installation-of-s3cmd-and-s5cmd-on-personal-system) for installation instructions specific to your operating system.
+Please note that the instructions mentioned above are specific to the Cheaha system. To transfer data between your personal computer and LTS, you will need to install `s3cmd` or `s5cmd` on your machine. Please refer to this [section](#installation-of-s3cmd-and-s5cmd-on-personal-system) for installation instructions specific to your operating system.
 
 <!-- markdownlint-disable MD046 -->
 !!! note
@@ -112,7 +116,7 @@ Save settings? [y/N] y
     2. To locate the appropriate "Path to GPG program" for Ubuntu and Mac operating systems, please use the command `which gpg`. The location may vary depending on your operating system.
 <!-- markdownlint-enable MD046 -->
 
-### s3cmd Commands
+#### s3cmd Commands
 
 ``` bash
 # General command structure for s3cmd
@@ -172,7 +176,7 @@ s3cmd info s3://<bucket>
 
 s5cmd is a parallel transfer tool suggested for period transfers of large and/or many files at a time. It has options for customizing how many processors are available for transferring data as well as how many chunks files can be broken into during transfer to minimize transfer time. See the [preceding section](#command-line) for instructions on how to install both it and s3cmd into an Anaconda environment
 
-### s5cmd Configuration
+#### Configuring s5cmd
 
 s5cmd does not use the same authentication file as s3cmd. Instead, it uses official AWS SDK to access S3 including LTS. The default credentials file for AWS CLI would found at `${HOME}/.aws/credentials`. This file is then populated with different profiles and their access and secret keys. You can create the necessary file with the following commands.
 
@@ -207,7 +211,7 @@ aws_access_key_id = <lab_access_key>
 aws_secret_access_key = <lab_secret_key>
 ```
 
-### s5cmd Commands
+#### s5cmd Commands
 
 s5cmd has the following general form.
 

--- a/docs/data_management/lts/interfaces.md
+++ b/docs/data_management/lts/interfaces.md
@@ -52,12 +52,6 @@ You may need to install `gpg` on a Mac using the below command,
 brew install gnupg
 ```
 
-To view the path of `gpg` installed, use the following command.
-
-```bash
-which gpg
-```
-
 #### Windows
 
 To install `s3cmd` on a Windows system, you will first need to install [Windows Subsystem for Linux (WSL)](../../uab_cloud/remote_access.md/#windows-subsystem-for-linux-wsl). Once WSL is installed, you can use the command line instructions for [Ubuntu](#ubuntu) to install `s3cmd`.

--- a/docs/data_management/lts/interfaces.md
+++ b/docs/data_management/lts/interfaces.md
@@ -199,7 +199,7 @@ s3cmd info s3://<bucket>
 
 s5cmd is a parallel transfer tool suggested for period transfers of large and/or many files at a time. It has options for customizing how many processors are available for transferring data as well as how many chunks files can be broken into during transfer to minimize transfer time. See the [preceding section](#command-line) for instructions on how to install both it and s3cmd into an Anaconda environment
 
-#### Configuring s5cmd on Cheaha
+#### Configuring s5cmd
 
 s5cmd does not use the same authentication file as s3cmd. Instead, it uses official AWS SDK to access S3 including LTS. The default credentials file for AWS CLI would found at `${HOME}/.aws/credentials`. This file is then populated with different profiles and their access and secret keys. You can create the necessary file with the following commands.
 

--- a/docs/data_management/lts/interfaces.md
+++ b/docs/data_management/lts/interfaces.md
@@ -52,9 +52,13 @@ Please note that the instructions mentioned above are specific to the Cheaha sys
     We manually install pip into the conda environment so that `pip` will install `s3cmd` into the conda environment as opposed to `$HOME/.local`. This way, you do not need to add the `.local` folder to your path whenever you want to use `s3cmd`.
 <!-- markdownlint-enable MD046 -->
 
-### s3cmd Configuration
+### s3cmd
 
-s3cmd is our suggested tool for managing bucket permissions and small, periodic file transfers. See the [preceding section](#command-line) for instructions on how to install both it and s5cmd into an Anaconda environment. Once you have s3cmd installed and the environment active, you can start the configuration process like so:
+s3cmd is a tool used for managing buckets and objects in Amazon S3 (Simple Storage Service). s3cmd is our suggested tool for operations such as listing buckets, managing bucket permissions, synchronizing directories with s3 buckets, and for small periodic file transfers. If high-speed transfer of a large files is required, we recommend using [s5cmd](#s5cmd). See the [preceding section](#command-line) for instructions on how to install both it and s5cmd into an Anaconda environment.
+
+#### Configuring s3cmd
+
+Configuring s3cmd is necessary to establish a secure connection for accessing your LTS bucket in Amazon S3. Once you have s3cmd installed and the environment active, you can start the configuration process like so:
 
 ``` bash
 s3cmd --configure [-c $HOME/profile_name]

--- a/docs/data_management/lts/interfaces.md
+++ b/docs/data_management/lts/interfaces.md
@@ -29,35 +29,6 @@ While globus is the recommended tool for most data transfers, command line tools
 1. [s3cmd](https://github.com/s3tools/s3cmd) is a Python tool that we suggest using for managing bucket permissions as well as small transfers.
 2. [s5cmd](https://github.com/peak/s5cmd) is a Go package that transfers data much more quickly than s3cmd, especially as the file size and/or quanitity increases. It does not have full bucket management capabilities.
 
-### Installation of `s3cmd` and `s5cmd` on Personal System
-
-The installation instructions and software dependencies may differ depending on the operating system being used. Following are the installation instructions tested for different operating systems.
-
-#### Ubuntu
-
-```bash
-sudo apt update
-sudp apt install s3cmd
-```
-
-#### Mac
-
-```bash
-brew install s3cmd
-```
-
-You may need to install `gpg` on a Mac using the below command,
-
-```bash
-brew install gnupg
-```
-
-#### Windows
-
-To install `s3cmd` on a Windows system, you will first need to install [Windows Subsystem for Linux (WSL)](../../uab_cloud/remote_access.md/#windows-subsystem-for-linux-wsl). Once WSL is installed, you can use the command line instructions for [Ubuntu](#ubuntu) to install `s3cmd`.
-
-For more information on s3cmd, please refer to the official [s3tools Page](https://s3tools.org/download).
-
 ### Installation of `s3cmd` and `s5cmd` on Cheaha
 
 To install the tools on Cheaha, you can request a compute node through Cheaha's [Open OnDemand web portal](../../cheaha/open_ondemand/ood_layout.md/#creating-an-interactive-job).Once your job is launched, open a terminal to execute the commands listed below. You do not need to install both tools if they aren't necessary. Both are available to install into [Anaconda](../../workflow_solutions/using_anaconda.md) environments. It's suggested to create a single environment named `s3` and install both s3cmd and s5cmd into it for easy access to both tools. Specific install and usage commands for each are given in their respective sections. You can create the general environment using the following commands:
@@ -68,6 +39,8 @@ conda create -n s3 -c conda-forge pip s5cmd
 conda activate s3
 pip install s3cmd
 ```
+
+Please note that the instructions mentioned above are specific to the Cheaha system. If you need to transfer data between your personal computer and LTS, you'll need to install `s3cmd` and `s5cmd` on your machine. Please refer to this [section](#installation-of-s3cmd-and-s5cmd-on-personal-system) for installation instructions specific to your operating system.
 
 <!-- markdownlint-disable MD046 -->
 !!! note
@@ -139,7 +112,7 @@ Save settings? [y/N] y
     2. To locate the appropriate "Path to GPG program" for Ubuntu and Mac operating systems, please use the command `which gpg`. The location may vary depending on your operating system.
 <!-- markdownlint-enable MD046 -->
 
-#### s3cmd Commands
+### s3cmd Commands
 
 ``` bash
 # General command structure for s3cmd
@@ -199,7 +172,7 @@ s3cmd info s3://<bucket>
 
 s5cmd is a parallel transfer tool suggested for period transfers of large and/or many files at a time. It has options for customizing how many processors are available for transferring data as well as how many chunks files can be broken into during transfer to minimize transfer time. See the [preceding section](#command-line) for instructions on how to install both it and s3cmd into an Anaconda environment
 
-#### Configuring s5cmd
+### s5cmd Configuration
 
 s5cmd does not use the same authentication file as s3cmd. Instead, it uses official AWS SDK to access S3 including LTS. The default credentials file for AWS CLI would found at `${HOME}/.aws/credentials`. This file is then populated with different profiles and their access and secret keys. You can create the necessary file with the following commands.
 
@@ -234,7 +207,7 @@ aws_access_key_id = <lab_access_key>
 aws_secret_access_key = <lab_secret_key>
 ```
 
-#### s5cmd Commands
+### s5cmd Commands
 
 s5cmd has the following general form.
 
@@ -267,6 +240,54 @@ It's important to note that the main functionality of s5cmd over s3cmd is the pa
 
     When setting the value for `--numworkers`, do not select a value beyond the number of CPUs you have requested for your job! This can cause high context switching (meaning individual CPUs are switching between multiple running processes) which can affect job performance for all jobs on a node.
 <!-- markdownlint-enable MD046 -->
+
+### Installation of `s3cmd` and `s5cmd` on Personal System
+
+The installation instructions and software dependencies may differ depending on the operating system being used. Following are the installation instructions tested for different operating systems.
+
+- Ubuntu
+
+    To install `s3cmd` using the following command,
+
+    ```bash
+    sudo apt update
+    sudp apt install s3cmd
+    ```
+
+    To install `s5cmd`, you will have to first install `go` software version 1.19+. Please refer to the [Download page](https://go.dev/dl/), and [installation instruction](https://go.dev/doc/install) for further details. After intalling `go`, you can build `s5cmd` in your `$HOME` directory using the below steps.
+
+    ```bash
+    cd $HOME
+    go install github.com/peak/s5cmd/v2@master
+    ```
+
+    The below steps are to add `go` bin directory to your system's `PATH` which allows you to run `s5cmd` from any location in your terminal.
+
+    ```bash
+    echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.bashrc
+    source ~/.bashrc
+    ```
+
+- Mac
+
+    Following are installation commands for `s3cmd` and `s5cmd` on a Mac System.
+
+    ```bash
+    brew install s3cmd
+    brew install peak/tap/s5cmd
+    ```
+
+    You may need to install `gpg` on a Mac using the below command,
+
+    ```bash
+    brew install gnupg
+    ```
+
+- Windows
+
+    To install `s3cmd` and `s5cmd` on a Windows system, you will first need to install [Windows Subsystem for Linux (WSL)](../../uab_cloud/remote_access.md/#windows-subsystem-for-linux-wsl). Once WSL is installed, you can use the command line instructions for [Ubuntu](#ubuntu) to install `s3cmd` and `s5cmd`.
+
+    For more information on `s3cmd` and `s5cmd`, please refer to the official [s3tools Page](https://s3tools.org/download), and [s5cmd page](https://github.com/peak/s5cmd?tab=readme-ov-file).
 
 ## Alternatives
 

--- a/docs/data_management/lts/interfaces.md
+++ b/docs/data_management/lts/interfaces.md
@@ -1,6 +1,6 @@
 # Connecting to LTS
 
-LTS is not available as a mounted filesystem on local computers or Cheaha. You must use an interface to transfer data between LTS and whichever machine you are using. There a variety of interfaces with the following recommendations.
+LTS is not available as a mounted filesystem on local computers or Cheaha. You must use an interface to transfer data between LTS and whichever machine you are using. There are a variety of interfaces with the following recommendations.
 
 ## Globus
 
@@ -29,7 +29,44 @@ While globus is the recommended tool for most data transfers, command line tools
 1. [s3cmd](https://github.com/s3tools/s3cmd) is a Python tool that we suggest using for managing bucket permissions as well as small transfers.
 2. [s5cmd](https://github.com/peak/s5cmd) is a Go package that transfers data much more quickly than s3cmd, especially as the file size and/or quanitity increases. It does not have full bucket management capabilities.
 
-You do not need to install both tools if they aren't necessary. Both are available to install into [Anaconda](../../workflow_solutions/using_anaconda.md) environments. It's suggested to create a single environment named `s3` and install both s3cmd and s5cmd into it for easy access to both tools. Specific install and usage commands for each are given in their respective sections. You can create the general environment using the following commands:
+### Installation of `s3cmd` and `s5cmd` on Personal System
+
+The installation instructions and software dependencies may differ depending on the operating system being used. Following are the installation instructions tested for different operating systems.
+
+#### Ubuntu
+
+```bash
+sudo apt update
+sudp apt install s3cmd
+```
+
+#### Mac
+
+```bash
+brew install s3cmd
+```
+
+You may need to install `gpg` on a Mac using the below command,
+
+```bash
+brew install gnupg
+```
+
+To view the path of `gpg` installed, use the following command.
+
+```bash
+which gpg
+```
+
+#### Windows
+
+To install `s3cmd` on a Windows system, you will first need to install [Windows Subsystem for Linux (WSL)](../../uab_cloud/remote_access.md/#windows-subsystem-for-linux-wsl). Once WSL is installed, you can use the command line instructions for [Ubuntu](#ubuntu) to install `s3cmd`.
+
+For more information on s3cmd, please refer to the official [s3tools Page](https://s3tools.org/download).
+
+### Installation of `s3cmd` and `s5cmd` on Cheaha
+
+To install the tools on Cheaha, you can request a compute node through Cheaha's [Open OnDemand web portal](../../cheaha/open_ondemand/ood_layout.md/#creating-an-interactive-job).Once your job is launched, open a terminal to execute the commands listed below. You do not need to install both tools if they aren't necessary. Both are available to install into [Anaconda](../../workflow_solutions/using_anaconda.md) environments. It's suggested to create a single environment named `s3` and install both s3cmd and s5cmd into it for easy access to both tools. Specific install and usage commands for each are given in their respective sections. You can create the general environment using the following commands:
 
 ``` bash
 module load Anaconda3
@@ -44,7 +81,7 @@ pip install s3cmd
     We manually install pip into the conda environment so that `pip` will install `s3cmd` into the conda environment as opposed to `$HOME/.local`. This way, you do not need to add the `.local` folder to your path whenever you want to use `s3cmd`.
 <!-- markdownlint-enable MD046 -->
 
-### s3cmd
+### s3cmd Configuration
 
 s3cmd is our suggested tool for managing bucket permissions and small, periodic file transfers. See the [preceding section](#command-line) for instructions on how to install both it and s5cmd into an Anaconda environment. Once you have s3cmd installed and the environment active, you can start the configuration process like so:
 
@@ -102,9 +139,10 @@ Save settings? [y/N] y
 ```
 
 <!-- markdownlint-disable MD046 -->
-!!! note
+!!! important
 
-    If you choose to test access using your credentials, the test may fail. Do not rely on the automatic test results, test access yourself by either creating a bucket or listing files from a existing bucket using the commands listed below.
+    1. If you choose to test access using your credentials, the test may fail. Do not rely on the automatic test results, test access yourself by either creating a bucket or listing files from a existing bucket using the commands listed below.
+    2. To locate the appropriate "Path to GPG program" for Ubuntu and Mac operating systems, please use the command `which gpg`. The location may vary depending on your operating system.
 <!-- markdownlint-enable MD046 -->
 
 #### s3cmd Commands
@@ -167,7 +205,7 @@ s3cmd info s3://<bucket>
 
 s5cmd is a parallel transfer tool suggested for period transfers of large and/or many files at a time. It has options for customizing how many processors are available for transferring data as well as how many chunks files can be broken into during transfer to minimize transfer time. See the [preceding section](#command-line) for instructions on how to install both it and s3cmd into an Anaconda environment
 
-#### Configuring s5cmd
+#### Configuring s5cmd on Cheaha
 
 s5cmd does not use the same authentication file as s3cmd. Instead, it uses official AWS SDK to access S3 including LTS. The default credentials file for AWS CLI would found at `${HOME}/.aws/credentials`. This file is then populated with different profiles and their access and secret keys. You can create the necessary file with the following commands.
 


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview
Updates to LTS s3cmd and s5cmd  installation

## Proposed Changes
1. Included instructions for installing `s3cmd` and `s5cmd` on PC.
2. Incorporated changes to the installation guide for `s3cmd` specific to Cheaha.
3. Updated admonition to locate `gpg` path.
4. Updated Section ordering.
5. Added s3cmd intro.
<!-- Provide specific details of what is changing -->

## Related Issues
Fixes #695 
Fixes #729 
<!--
Examples:
Fixes #695 
Related to #101
-->
