### PR TITLE
updated scratch deletion policy

### DIFF
--- a/docs/data_management/storage.md
+++ b/docs/data_management/storage.md
@@ -184,6 +184,9 @@ Network scratch is available on the login node and each compute node. This stora
 !!! warning
 
     Research Computing expects each user to keep their scratch areas clean. **The cluster scratch areas are not to be used for archiving data.** In order to keep scratch clear and usable for everyone, files older than 30 days will be automatically deleted.
+
+    **note**: Data held in user scratch may be retained on the system for 30 days. After 30 days, we may delete data to free space. **The user scratch pool is a shared resource**, so please treat it as temporary storage.
+    
 <!-- markdownlint-enable MD046 -->
 
 ### Local Scratch


### PR DESCRIPTION
<h3>Missing Scratch Deletion Policy from User Scratch Section</h3>

![note](https://github.com/user-attachments/assets/a4d4fc0a-62aa-457d-acf2-7889cdc9c1ec)


I recently worked on updating the User Scratch section on the website. To inform users about data retention, I added a note indicating that data may be deleted after 30 days. I hope this update helps in building greater trust with users.

