### PR TITLE
Change ci to use miniforge instead of miniconda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
           config: .markdownlint-cli2.jsonc
           globs: "**/*.md"
 
-      - name: Setup Miniconda
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniconda-version: latest
+          miniforge-version: latest
           conda-solver: libmamba
           environment-file: build_env.yml
           activate-environment: build


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

Change CI/CD to use Miniforge instead of Miniconda.

## Proposed Changes

See above.

## Related Issues

Fixes #776 
