### PR TITLE
Made edits to some of the links

### DIFF
--- a/docs/data_management/transfer/rclone.md
+++ b/docs/data_management/transfer/rclone.md
@@ -60,7 +60,7 @@ To instead install natively on Windows, you will need to use the following instr
 
 ### MacOS
 
-Follow the [online instructions](https://rclone.org/install/#macos-installation-with-brew) for installing with `brew`.
+Follow the [online instructions](https://rclone.org/install/#macos-brew) for installing with `brew`.
 
 ## Setting up Remotes
 

--- a/docs/uab_cloud/installing_software.md
+++ b/docs/uab_cloud/installing_software.md
@@ -147,7 +147,7 @@ Miniconda is a lightweight version of Anaconda. While Anaconda's base environmen
 
 #### Installing Singularity
 
-Follow the instructions located at <https://sylabs.io/guides/3.9/user-guide/quick_start.html#install-system-dependencies> under "Debian-based systems".
+Follow the instructions located at <https://docs.sylabs.io/guides/3.9/user-guide/quick_start.html#install-system-dependencies> under "Debian-based systems".
 
 1. Run the commands in [Before Installing Software](#before-installing-software).
 1. Run the following
@@ -193,7 +193,7 @@ Follow the instructions located at <https://sylabs.io/guides/3.9/user-guide/quic
 <!-- markdownlint-disable MD046 -->
 !!! note
 
-    For other versions of the Singularity documentation, visit <https://sylabs.io/docs/>.
+    For other versions of the Singularity documentation, visit <https://docs.sylabs.io/docs/>.
 <!-- markdownlint-enable MD046 -->
 
 #### Installing Jupyter Server

--- a/docs/uab_cloud/remote_access.md
+++ b/docs/uab_cloud/remote_access.md
@@ -19,7 +19,7 @@ There are two main steps to working with SSH efficiently. The first is to ensure
 Terminal multiplexers are software that aggregate multiple SSH client sessions into one location. They often have the added benefit of keeping sessions alive on the remote machine, so short internet outages won't require you to log in again.
 
 - For Linux, try using `tmux`: <https://github.com/tmux/tmux/wiki/Installing#installing-tmux>
-- For Windows, try using Windows Terminal: <https://apps.microsoft.com/detail/9n0dx20hk701?hl=en-gb&gl=US>
+- For Windows, try using Windows Terminal: <https://apps.microsoft.com/detail/9n0dx20hk701?hl=en-us&gl=US>
 
 ### Install an SSH Client (Linux)
 

--- a/docs/uab_cloud/remote_access.md
+++ b/docs/uab_cloud/remote_access.md
@@ -18,8 +18,8 @@ There are two main steps to working with SSH efficiently. The first is to ensure
 
 Terminal multiplexers are software that aggregate multiple SSH client sessions into one location. They often have the added benefit of keeping sessions alive on the remote machine, so short internet outages won't require you to log in again.
 
-- For Linux, try using `tmux`: <https://github.com/tmux/tmux/wiki/Installing>
-- For Windows, try using Windows Terminal: <https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701>
+- For Linux, try using `tmux`: <https://github.com/tmux/tmux/wiki/Installing#installing-tmux>
+- For Windows, try using Windows Terminal: <https://apps.microsoft.com/detail/9n0dx20hk701?hl=en-gb&gl=US>
 
 ### Install an SSH Client (Linux)
 

--- a/docs/workflow_solutions/git.md
+++ b/docs/workflow_solutions/git.md
@@ -28,7 +28,7 @@ Denser and more complete documentation is available at <https://git-scm.com/doc>
     - Repositories are decentralized, so that two people can work independently on parts of the same project and then merge their changes later.
     - A **local repository** is a repository that is housed on the same machine you are working on.
     - A **remote repository** or **remote** is a repository that is housed on a machine other than the one you are working on.
-    - Remotes are often housed on internet repository services like <https://github.com> and <https://gitlab.org>. UAB also maintains a private Gitlab instance at <https://gitlab.rc.uab.edu>.
+    - Remotes are often housed on internet repository services like <https://github.com> and <https://about.gitlab.com>. UAB also maintains a private Gitlab instance at <https://gitlab.rc.uab.edu>.
 - The **working tree** is the structure used to model repository contents and history.
 - The **index** contains changes since the most recent commit.
 - The **staging area**, a subset of the index, contains changes ready to be committed.

--- a/docs/workflow_solutions/git_collaboration.md
+++ b/docs/workflow_solutions/git_collaboration.md
@@ -94,7 +94,7 @@ The workflow assumes a central repository already exists within an organization 
     1. [Clone](git.md#cloning) the downstream fork to the local machine where the programming will happen.
 - Workflow
     1. Decide on a set of changes to make. Good practice is only working on one conceptual unit at a time. One feature, one bug fix, or one documentation page. Prefer fixing bugs before adding features.
-    1. Synchronize your downstream fork with the upstream fork to minimize risk of merge conflicts. [GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) [GitLab](https://docs.gitlab.com/ee/user/project/repository/forking_workflow.html#repository-mirroring)
+    1. Synchronize your downstream fork with the upstream fork to minimize risk of merge conflicts. [GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) [GitLab](https://docs.gitlab.com/ee/user/project/repository/forking_workflow.html)
     1. [Pull the downstream fork main branch](git.md#fetching-and-pulling) to your local clone main branch.
     1. [Create a working branch](git.md#creating-new-branches) for intended changes. Give it a short, descriptive name like `feature-add-button` or `fix-broken-link`.
     1. [Checkout the working branch](git.md#checking-out-existing-branches).
@@ -117,7 +117,7 @@ Effective use of issue tracking can greatly reduce cognitive load and simplify c
 
 The typical issue lifecycle, at a high level, is something like below.
 
-1. Create an issue. [GitHub](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue) [GitLab](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#create-an-issue)
+1. Create an issue. [GitHub](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue) [GitLab](https://docs.gitlab.com/ee/user/project/issues/create_issues.html)
 1. Ask for clarifications and discuss as needed.
 1. Use the [Fork-Pull/Merge Request Workflow](#the-fork-pullmerge-request-workflow) to resolve the issue. In the Pull Request description, put the text `Fixes #...` where `...` should be replaced by the issue's number. When the request is merged, the issue will automatically be linked to the request and closed.
 

--- a/docs/workflow_solutions/git_collaboration.md
+++ b/docs/workflow_solutions/git_collaboration.md
@@ -94,7 +94,7 @@ The workflow assumes a central repository already exists within an organization 
     1. [Clone](git.md#cloning) the downstream fork to the local machine where the programming will happen.
 - Workflow
     1. Decide on a set of changes to make. Good practice is only working on one conceptual unit at a time. One feature, one bug fix, or one documentation page. Prefer fixing bugs before adding features.
-    1. Synchronize your downstream fork with the upstream fork to minimize risk of merge conflicts. [GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) [GitLab](https://docs.gitlab.com/ee/user/project/repository/forking_workflow.html)
+    1. Synchronize your downstream fork with the upstream fork to minimize risk of merge conflicts. [GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) [GitLab](https://docs.gitlab.com/ee/user/project/repository/forking_workflow.html#update-your-fork)
     1. [Pull the downstream fork main branch](git.md#fetching-and-pulling) to your local clone main branch.
     1. [Create a working branch](git.md#creating-new-branches) for intended changes. Give it a short, descriptive name like `feature-add-button` or `fix-broken-link`.
     1. [Checkout the working branch](git.md#checking-out-existing-branches).


### PR DESCRIPTION
# Pull Request



## Overview

Made edits to the sections below

* Change https://rclone.org/install/#macos-installation-with-brew to https://rclone.org/install/#macos-brew
* Change https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701 to https://apps.microsoft.com/detail/9n0dx20hk701?hl=en-us&gl=US
* Change Singularity docs links from sylabs.io to docs.sylabs.io
* Some anchors for docs.github.com and docs.gitlab.com URLs have changed.
* gitlab.org moved to about.gitlab.com

## Proposed Changes

<!-- Provide specific details of what is changing -->

## Related Issues


#773  
