### PR TITLE
Fixes Some of the Listed Broken URLs for Sprint 24-16

### DIFF
--- a/docs/data_management/storage.md
+++ b/docs/data_management/storage.md
@@ -317,8 +317,8 @@ Cheaha is HIPAA compliant and can accept Protected Health Information (PHI) data
 For UAB policies surrounding PHI data, please see the following URLs.
 
 - [Data Classification](https://www.uab.edu/it/home/policies/data-classification/classification-overview)
-- [Data Protection and Security Policy](https://secure2.compliancebridge.com/uab/portal/getdoc.php?file=302)
-- [Data Access Policy](https://secure2.compliancebridge.com/uab/portal/getdoc.php?file=301)
+- [Data Protection and Security Policy](https://secure4.compliancebridge.com/uab/portal/getdoc.php?file=302)
+- [Data Access Policy](https://secure4.compliancebridge.com/uab/portal/getdoc.php?file=301)
 - [HIPAA Data Policy](https://www.uab.edu/it/home/policies/compliance/hipaa)
 
 <!-- markdownlint-disable MD046 -->

--- a/docs/data_management/transfer/globus.md
+++ b/docs/data_management/transfer/globus.md
@@ -11,13 +11,13 @@ UAB Research Computing uses High Assurance Endpoints, meaning there are addition
 
 For more detailed information on High Assurance please see the Globus official pages below:
 
-- [High Assurance Security Overview](https://docs.globus.org/security/high-assurance-overview/)
-- [High Assurance Collections](https://docs.globus.org/high-assurance/)
+- [High Assurance Security Overview](https://docs.globus.org/guides/overviews/security/high-assurance-overview/)
+- [High Assurance Collections](https://docs.globus.org/guides/overviews/high-assurance/)
 
 ## Setting up Globus Connect Personal
 
 [Globus Connect Personal](https://www.globus.org/globus-connect-personal) is software meant to be installed on local machines such as laptops, desktops,
-workstations and self-owned, local-scale servers. Globus maintains excellent documentation for installation on [MacOS](https://docs.globus.org/how-to/globus-connect-personal-mac/), [Linux](https://docs.globus.org/how-to/globus-connect-personal-linux) and [Windows](https://docs.globus.org/how-to/globus-connect-personal-windows).
+workstations and self-owned, local-scale servers. Globus maintains excellent documentation for installation on [MacOS](https://docs.globus.org/globus-connect-personal/install/mac/), [Linux](https://docs.globus.org/globus-connect-personal/install/linux/) and [Windows](https://docs.globus.org/globus-connect-personal/install/windows/).
 
 To verify your installation is complete, please visit <https://app.globus.org> and log in. Click "Collections" in the left-hand navigation pane and then click the "Administered By You" tab. Look in the table for the collection you just created.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ For additional information please see [Support](./help/support.md).
 
 RCS is developed and supported by UAB IT's Research Computing Group. We are developing a core set of applications to help you to easily incorporate our services into your research processes and this documentation collection to help you leverage the resources already available. We follow the best practices of the Open Source community and develop our software in an open-source fashion.
 
-RCS is an out growth of the UABgrid pilot, launched in September 2007 which has focused on demonstrating the utility of unlimited analysis, storage, and application for research. RCS is built on the same technology foundations used by major cloud vendors and decades of distributed systems computing research, technology that powered the last ten years of large scale systems serving prominent national and international initiatives like the [Open Science Grid](https://opensciencegrid.org/), [XSEDE](https://www.xsede.org/), the [LHC Computing Grid](https://wlcg.web.cern.ch/), and [NCIP](https://datascience.cancer.gov/).
+RCS is an out growth of the UABgrid pilot, launched in September 2007 which has focused on demonstrating the utility of unlimited analysis, storage, and application for research. RCS is built on the same technology foundations used by major cloud vendors and decades of distributed systems computing research, technology that powered the last ten years of large scale systems serving prominent national and international initiatives like the [Open Science Grid](https://osg-htc.org/), [XSEDE](https://www.xsede.org/), the [LHC Computing Grid](https://wlcg.web.cern.ch/), and [NCIP](https://datascience.cancer.gov/).
 
 ## Outreach
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -14,7 +14,7 @@ The list of policies below are those that may be most relevant to typical use ca
 
 ### Acceptable Use Policy (AUP)
 
-[Acceptable Use Policy](https://secure2.compliancebridge.com/uab/public/index.php?fuseaction=print.preview&docID=786)
+[Acceptable Use Policy](https://secure4.compliancebridge.com/uab/public/index.php?fuseaction=app.main)
 
 ### Data Classification
 

--- a/docs/workflow_solutions/getting_containers.md
+++ b/docs/workflow_solutions/getting_containers.md
@@ -193,7 +193,7 @@ We require numpy, scipy, and matplotlib libraries to execute the above Python sc
     && rm -rf /var/lib/apt/lists/*
     ```
 
-    This is the specification file. It provides Docker with the software information, and versions, it needs to build our new container. See the Docker Container documentation for more information <https://docs.docker.com/engine/reference/builder/>.
+    This is the specification file. It provides Docker with the software information, and versions, it needs to build our new container. See the Docker Container documentation for more information <https://docs.docker.com/reference/dockerfile/>.
 
     In the Dockerfile, we start with an existing container `continuumio/miniconda3:4.12.0`. This container is obtained from Dockerhub; here, `continuumio` is the producer, and the repo name is `continuumio/miniconda3`.
 
@@ -285,7 +285,7 @@ python python_test.py
 
 ![!Containers python script execution.](./images/containers_python_script_execution.png)
 
-More lessons on Docker can be found in this link: [Introduction to Docker](https://christinalk.github.io/docker-introduction/) and [Docker Documentation](https://docs.docker.com/engine/reference/builder/).
+More lessons on Docker can be found in this link: [Introduction to Docker](https://christinalk.github.io/docker-introduction/) and [Docker Documentation](https://docs.docker.com/reference/dockerfile/).
 
 ## Sharing Containers Using UAB GitLab Container Registry
 
@@ -333,7 +333,7 @@ Once you create the token, copy the new personal access token since it’s a one
 ![!Containers gitlab login success.](./images/containers_gitlab_login_success.png)
 
 !!! warning
-    Running `docker login` leads to a warning message that your password is stored unencrypted in `/root/.docker/config.json` (or) `$HOME/.docker/config.json`. To ignore this warning, follow the instructions in this [Github page](https://leimao.github.io/blog/Docker-Login-Encrypted-Credentials/) or the [Docker credentials store page](https://docs.docker.com/engine/reference/commandline/login/#credentials-store).
+    Running `docker login` leads to a warning message that your password is stored unencrypted in `/root/.docker/config.json` (or) `$HOME/.docker/config.json`. To ignore this warning, follow the instructions in this [Github page](https://leimao.github.io/blog/Docker-Login-Encrypted-Credentials/) or the [Docker credentials store page](https://docs.docker.com/reference/cli/docker/login/#credentials-store).
 
 ### Push Alpine Container from your System to UAB GitLab Container Registry
 


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview and Proposed Changes
Fixed Some of the Listed Broken URLs,

1. Changed all IT policy URLs to start with https://secure4.compliancebridge.com/uab/portal
2. Changed OSG (Open ScienceGrid) URL to: https://osg-htc.org/
3. Changed Docker links to "docs.docker.com/reference" instead of "docs.docker.com/engine/reference"
4. Changed "docs.globus.org" URLs with updated URLs
<!-- Briefly summarize the proposed changes -->

## Related Issues

Fixes part of #773 
<!--
Examples:
Fixes #123
Related to #101
-->
