### PR TITLE
Update broken URLs

### DIFF
--- a/docs/uab_cloud/remote_access.md
+++ b/docs/uab_cloud/remote_access.md
@@ -37,7 +37,7 @@ There are several options for installing an SSH client on Windows, described bel
 
 #### Windows Subsystem For Linux (WSL)
 
-Follow the instructions starting [here](https://docs.microsoft.com/en-us/windows/wsl/about) to install Windows Subsystem for Linux.
+Follow the instructions starting [here](https://learn.microsoft.com/en-us/windows/wsl/about) to install Windows Subsystem for Linux.
 
 WSL shells do not automatically start or share the `ssh-agent`. To fix this we recommend installing `keychain` to automatically manage the `ssh-agent`. Run the following command depending on your Linux distribution.
 
@@ -59,7 +59,7 @@ Then modify the `.*rc` file for your shell, generally `.bashrc` or `.zshrc`, to 
 
 #### OpenSSH for Windows
 
-Follow the instructions [here](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse) to install the OpenSSH client. Only install the OpenSSH server if you need it, otherwise skip that part.
+Follow the instructions [here](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse) to install the OpenSSH client. The client software is all that is needed to connect with instances from your Windows PC. Only install the OpenSSH server if you are sure you need it (this is very uncommon). The instructions at the link should work for Windows 10 and Windows 11.
 
 Once the OpenSSH client is installed, you'll want to enable the OpenSSH Agent service on your local machine to streamline adding and using keys.
 
@@ -108,7 +108,7 @@ fi
 <!-- markdownlint-disable MD046 -->
 !!! tip
 
-    Git Bash can also be used with [Windows Terminal](#terminal-multiplexers) using this stackoverflow answer: <https://stackoverflow.com/a/57369284>.
+    Git Bash can also be used with [Windows Terminal](#terminal-multiplexers) using this stackoverflow answer: <https://stackoverflow.com/questions/56839307/adding-git-bash-to-the-new-windows-terminal/57369284>.
 <!-- markdownlint-enable MD046 -->
 
 ### Generating Key Pairs
@@ -152,7 +152,7 @@ If `ssh-agent` isn't already running and you encounter an error, use the followi
     <!-- markdownlint-disable MD046 -->
     !!! bug
 
-        For Linux users and [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) on Windows users. If you experience a `Warning: Unprotected Private Key File` error when using `ssh-add`, your `ssh` file and directory permissions may be incorrect. To fix, please use the following commands.
+        For Linux users and [WSL](https://learn.microsoft.com/en-us/windows/wsl/about) on Windows users. If you experience a `Warning: Unprotected Private Key File` error when using `ssh-add`, your `ssh` file and directory permissions may be incorrect. To fix, please use the following commands.
 
         ```bash
         sudo chmod 600 ~/.ssh/<private_key_file>

--- a/docs/workflow_solutions/r_environments.md
+++ b/docs/workflow_solutions/r_environments.md
@@ -2,7 +2,7 @@
 
 When working on multiple projects, it's likely that different sets of external analysis packages and their dependencies will be needed for each project. Managing these different projects is simple in something like [Anaconda](using_anaconda.md) by creating a different virtual environment for each project, but this functionality is not fully built into RStudio by default.
 
-Instead, we suggest to take advantage of [R Projects](https://support.rstudio.com/hc/en-us/articles/200526207-Using-RStudio-Projects) and the [renv](https://rstudio.github.io/renv/articles/renv.html) package to keep environments separate for each project you start.
+Instead, we suggest to take advantage of [R Projects](https://support.posit.co/hc/en-us/articles/200526207-Using-RStudio-Projects) and the [renv](https://rstudio.github.io/renv/articles/renv.html) package to keep environments separate for each project you start.
 
 <!-- markdownlint-disable MD046 -->
 !!! important


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

<!-- Briefly summarize the proposed changes -->

## Proposed Changes

- [x] Change `support.rstudio.com` to `support.posit.co`. There may be more details, so ensure the URL still works.
- [x] Expand stackexchange short URLs (https://stackoverflow.com/a/57369284) to their full form (https://stackoverflow.com/questions/56839307/adding-git-bash-to-the-new-windows-terminal/57369284#57369284)
- [x] Change docs.microsoft.com changed to learn.microsoft.com. Double check the URLs work

<!-- Provide specific details of what is changing -->

## Related Issues

Related to #773 
