### PR TITLE
Refining linkchecker output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,4 @@ $RECYCLE.BIN/
 
 site/
 test.py
+out/

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -85,7 +85,7 @@ fileoutput=csv
 
 # CSV logger
 [csv]
-#filename=linkchecker-out.csv
+filename=out/linkchecker-out.csv
 separator=,
 #quotechar="
 #dialect=excel

--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -86,10 +86,10 @@ fileoutput=csv
 # CSV logger
 [csv]
 #filename=linkchecker-out.csv
-#separator=;
+separator=,
 #quotechar="
 #dialect=excel
-#parts=all
+parts=result,urlname,parentname,line,column,url
 
 # SQL logger
 [sql]

--- a/docs/contributing/contributor_guide.md
+++ b/docs/contributing/contributor_guide.md
@@ -261,8 +261,8 @@ We use `.markdownlint.json` to handle markdown formatting rules, rather than pla
 We are using [linkchecker](https://github.com/linkchecker/linkchecker) to validate external repository URLs.
 
 1. Install `build-env.yml` and activate
-1. Run `linkchecker --config=.linkcheckerrc docs > linkchecker.log`
-1. Review `linkchecker-out.csv` (feel free to ignore `linkchecker.log` unless you want verbose details)
+1. Run `python scripts/linkchecker.py`
+1. Review `out/linkchecker-out.csv` (feel free to ignore `out/linkchecker.log` unless you want verbose details)
 
 #### Linting Known Issues
 

--- a/docs/contributing/contributor_guide.md
+++ b/docs/contributing/contributor_guide.md
@@ -264,6 +264,8 @@ We are using [linkchecker](https://github.com/linkchecker/linkchecker) to valida
 1. Run `python scripts/linkchecker.py`
 1. Review `out/linkchecker-out.csv` (feel free to ignore `out/linkchecker.log` unless you want verbose details)
 
+The `urlname` column contains the URL as it is written in the documentation. The `url` column contains the resulting URL after all forwarding is complete.
+
 #### Linting Known Issues
 
 There are known issues with the markdown linter and some of our non-standard plugins, especially admonitions (specifically a conflict involving fenced vs indented code blocks). To fix these cases please use one of the following methods. The `$MD_LINTER_CODE` can be found by hovering over the yellow squiggles in VSCode to bring up the warning lens.

--- a/scripts/linkchecker.py
+++ b/scripts/linkchecker.py
@@ -1,0 +1,28 @@
+import subprocess
+from pathlib import Path, PurePath
+
+import pandas as pd
+
+# Cleans up output of linkchecker
+
+OUTPUT = PurePath("out")
+Path(OUTPUT).mkdir(exist_ok=True)
+
+LINKCHECKER_LOG = OUTPUT / "linkchecker.log"
+LINKCHECKER_CSV = OUTPUT / "linkchecker-out.csv"
+
+
+if __name__ == "__main__":
+    with open(LINKCHECKER_LOG, "wb", buffering=0) as f:
+        subprocess.run("linkchecker --config=.linkcheckerrc docs", stdout=f)
+    df = pd.read_csv(LINKCHECKER_CSV)
+    df = df[["result", "urlname", "parentname", "line", "column", "url"]]
+
+    # drop good urls
+    same_url = df["urlname"] == df["url"]
+    result_ok = df["result"].str.startswith("200")
+    drop = same_url & result_ok
+    df = df[~drop]
+
+    # output
+    df.to_csv(LINKCHECKER_CSV, index=False)


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

<!-- Briefly summarize the proposed changes -->

Refines and simplifies linkchecker output.

## Proposed Changes

<!-- Provide specific details of what is changing -->

- Adds `scripts/linkchecker.py` as the primary source to run linkchecking.
- Updates contributor guide.
- Output files now go to `out/*`.
- Refined output file to contain only the necessary outputs.

## Related Issues

<!--
Examples:
Fixes #123
Related to #101
-->
