### PR TITLE
Make "no git revision date" info level to avoid build failure on new pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,7 +161,6 @@ nav:
       - Facilities and Plan: grants/facilities.md
       - Budgeting: grants/budgets.md
       - Descriptions: grants/publications.md
-      - Funding Opportunities: grants/opportunities.md
   - Outreach & Training:
       - Case Studies: education/case_studies.md
       - Research Computing Days:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ plugins:
       data_path: docs
   - git-revision-date-localized:
       type: date
+      strict: false
   - glightbox:
       # auto_caption: true
   - redirects:
@@ -160,6 +161,7 @@ nav:
       - Facilities and Plan: grants/facilities.md
       - Budgeting: grants/budgets.md
       - Descriptions: grants/publications.md
+      - Funding Opportunities: grants/opportunities.md
   - Outreach & Training:
       - Case Studies: education/case_studies.md
       - Research Computing Days:


### PR DESCRIPTION
…pages

# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

<!-- Briefly summarize the proposed changes -->

See title. Currently new pages emit a build warning from the `mkdocs-git-revision-localized-date-plugin`. This change makes them `info` level. The net result is that new pages won't cause build failures.

## Proposed Changes

<!-- Provide specific details of what is changing -->

## Related Issues

<!--
Examples:
Fixes #123
Related to #101
-->
