### PR TITLE
Retrieve OOD log directory for past jobs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: mkdocs-build
         name: Build documentation
-        entry: "conda activate mkdocs && mkdocs build --strict"
+        entry: conda run -n mkdocs mkdocs build --strict
         language: system
         always_run: true
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: mkdocs-build
         name: Build documentation
-        entry: conda run -n mkdocs mkdocs build --strict
+        entry: "conda activate mkdocs && mkdocs build --strict"
         language: system
         always_run: true
         pass_filenames: false

--- a/docs/cheaha/open_ondemand/ood_layout.md
+++ b/docs/cheaha/open_ondemand/ood_layout.md
@@ -149,7 +149,13 @@ The Job ID and Session ID are important for diagnosing issues you may encounter 
 
 #### Debugging OOD Job Failures
 
-On occasion, interactive jobs created in OOD will crash on startup and cause the job card to disappear. Most of these failures are caused by improper environment setup prior to job creation. If you experiencing OOD job failures, retrieve the OOD job info using the following steps:
+On occasion, interactive jobs created in OOD will crash on startup and cause the job card to disappear. Most of these failures are caused by improper environment setup prior to job creation. To troubleshoot OOD applications, retrieving logs from failed jobs is essential. These logs are stored in `/data/user/$USER/ondemand/batch_connect/sys`, but each log directory is named using a hash value rather than a recognizable `JobID`, making it difficult to identify logs for a specific job after it has ended. To retrieve the correct log directory, use the following command:
+
+`sacct -j <jobid> -o jobid,workdir --parsable`
+
+This command retrieves the job's working directory, where the logs are stored. Replace `<jobid>` with the failed job ID when running the command.  Then, you can download the logs, zip them, and attach the ZIP file to a support ticket for our review. If you are unable to run the `sacct` command, please email <support@listserv.uab.edu>, and we will provide you with the necessary download link.
+
+Alternatively, you can create a new job and follow the steps below to retrieve and submit the log files.
 
 1. Create a new job with the same setup as the job that failed.
 1. When the job is in queue, click the link in the `Session ID` field in the job card before the job fails (see the image below for an example). This will open a file browser in a new tab.
@@ -158,7 +164,7 @@ On occasion, interactive jobs created in OOD will crash on startup and cause the
 
 1. Wait for the job to fail. Afterwards, refresh the file browser, select all of the files (do not include the `desktops` or `..` folders), and click `Download`.
 
-   ![!Files to be downloaded and attached to the email](./images/ood_failed_job.png)
+    ![!Files to be downloaded and attached to the email](images/ood_failed_job.png)
 
 1. Take all of the files that were downloaded, put them in a new folder, and zip the folder.
 


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

<!-- Briefly summarize the proposed changes -->

## Proposed Changes
- Added commands to retrieve OOD log directory for past jobs.
<!-- Provide specific details of what is changing -->

## Related Issues
Fixes #883 
<!--
Examples:
Fixes #123
Related to #101
-->
