### PR TITLE
Where to find CUDA and cuDNN conda packages

### DIFF
--- a/docs/cheaha/open_ondemand/ood_jupyter.md
+++ b/docs/cheaha/open_ondemand/ood_jupyter.md
@@ -24,7 +24,13 @@ module load cuDNN/8.9.2.26-CUDA-12.2.0
 
 For information on which versions of CUDA to load for Tensorflow and PyTorch, please see [Tensorflow Compatibility](../slurm/gpu.md#tensorflow-compatibility) and [PyTorch Compatibility](../slurm/gpu.md#pytorch-compatibility).
 
-For information on partition and GPU selection, please review our [hardware information page](../hardware.md) and [GPU Page](../slurm/gpu.md)
+For information on partition and GPU selection, please review our [hardware information page](../hardware.md) and [GPU Page](../slurm/gpu.md).
+
+<!-- markdownlint-disable MD046 -->
+!!! note
+
+    The latest CUDA and cuDNN are now available from [Conda](../slurm/gpu.md#cuda-and-cudnn-modules).
+<!-- markdownlint-enable MD046 -->
 
 ## Extra Jupyter Arguments
 

--- a/docs/cheaha/open_ondemand/ood_layout.md
+++ b/docs/cheaha/open_ondemand/ood_layout.md
@@ -108,6 +108,12 @@ For jobs such as RStudio and Jupyter, some modules like CUDA need to be loaded b
     In the OOD session, the module is automatically reset at the beginning of every session by default. Therefore, avoid using `module reset` in the 'Environment Setup' box. See [best practice for loading modules](../software/modules.md#best-practice-for-loading-modules) for more information.
 <!-- markdownlint-disable MD046 -->
 
+<!-- markdownlint-disable MD046 -->
+!!! note
+
+    The latest CUDA and cuDNN are now available from [Conda](../slurm/gpu.md#cuda-and-cudnn-modules).
+<!-- markdownlint-enable MD046 -->
+
 #### Launching Interactive Sessions
 
 Once you have completed the form fields with the necessary parameter for the job, click on the blue `Launch` button. The interactive session will be initiated and placed into the scheduling queue, changing the job state to `Queued`.

--- a/docs/cheaha/slurm/gpu.md
+++ b/docs/cheaha/slurm/gpu.md
@@ -70,7 +70,7 @@ If you are using R2021b and earlier, then follow the instructions below.
 
 1. Start an [HPC Interactive Desktop Job](../open_ondemand/hpc_desktop.md) with appropriate resources. Be sure to use one of the `pascalnodes*` [Partitions](#scheduling-gpus).
 1. Open a terminal.
-1. Load the appropriate [CUDA Module](#cuda-modules).
+1. Load the appropriate [CUDA Module](#cuda-and-cudnn-modules).
     - Determine which CUDA Modules are compatible with your required version of MATLAB using the table at the [MathWorks Site](https://www.mathworks.com/help/releases/R2021b/parallel-computing/gpu-support-by-release.html).
     - Check the `Pascal (cc6.x)` column for the `pascalnodes` P100 GPUs and `Ampere (cc8.x)` column for the `amperenodes` A100 GPUs.
     - As of September, 2023, `module load CUDA/11.6.0` and newer should work fine with any version of MATLAB R2021b or older, with possible caveats for some functions.
@@ -80,7 +80,7 @@ If you are using R2021b and earlier, then follow the instructions below.
 
 For more information and official MATLAB documentation please see this page: <https://www.mathworks.com/help/parallel-computing/gpu-computing-requirements.html>.
 
-## CUDA Modules
+## CUDA and cuDNN Modules
 
 You will need to load a CUDA module to make use of GPUs on Cheaha. Depending on which version of software you are using, different versions of CUDA module may be required. For instance, tensorflow version `2.13.0` requires the `CUDA/11.8.0` module. To see which versions are available on Cheaha, use the following command at the terminal.
 
@@ -88,11 +88,13 @@ You will need to load a CUDA module to make use of GPUs on Cheaha. Depending on 
 module -r spider 'CUDA/*'
 ```
 
-If a specific version of CUDA is needed but not installed, please send an install request to <support@listserv.uab.edu>.
+As of 2025-02-25, we offer CUDA modules up to version `12.6.0`. If you need a newer version, please use [Conda](../software/software.md#anaconda-on-cheaha) to install CUDA software from the `conda-forge` channel. The packages and relevant commands to install into your newly created [environment](../../workflow_solutions/using_anaconda.md#create-an-environment) are available at the URLs in the following table. Note that you should use different packages depending on the CUDA version you need for your software!
 
-### cuDNN Modules
+{{ read_csv('cheaha/slurm/res/cuda_conda_package_versions.csv', keep_default_na=False) }}
 
-If working with deep neural networks (DNNs, CNNs, LSTMs, LLMs, etc.), you will need to load a `cuDNN` module as well. The `cuDNN` modules are built to be compatible with a sibling `CUDA` module and are named with the corresponding version. For example, if you are loading `CUDA/12.2.0`, you will also need to load `cuDNN/8.9.2.26-CUDA-12.2.0`.
+If working with deep neural networks (DNNs, CNNs, LSTMs, LLMs, AI, etc.), you will need to load a `cuDNN` module as well. The `cuDNN` modules are built to be compatible with a sibling `CUDA` module and are named with the corresponding version. For example, if you are loading `CUDA/12.2.0`, you will also need to load `cuDNN/8.9.2.26-CUDA-12.2.0`.
+
+As of 2025-02-25, we offer cuDNN modules compatible with CUDA up to version `12.3.0`. If you need a newer version, please use [Conda](../software/software.md#anaconda-on-cheaha) to install cuDNN software from the `conda-forge` channel. The packages and relevant commands to install into your newly created [environment](../../workflow_solutions/using_anaconda.md#create-an-environment) are available at <https://anaconda.org/conda-forge/cudnn>.
 
 ### CUDA Compute Capability and Known Issues
 
@@ -107,6 +109,12 @@ GPU-based software requires a compatible [CUDA Compute Capability](../slurm/gpu.
 ### Tensorflow Compatibility
 
 To check which CUDA Module version is required for your version of Tensorflow, see the toolkit requirements chart here <https://www.tensorflow.org/install/source#gpu>.
+
+<!-- markdownlint-disable MD046 -->
+!!! note
+
+    The latest CUDA and cuDNN are now available from [Conda](#cuda-and-cudnn-modules).
+<!-- markdownlint-enable MD046 -->
 
 ### PyTorch Compatibility
 
@@ -127,6 +135,12 @@ For versions of PyTorch 1.13 and newer, use the following template instead.
 
      When loading modules, such as CUDA modules for jobs requiring one or more GPUs, always utilize `module reset` before loading modules, both at the terminal and within `sbatch` scripts. See [best practice for loading modules](../software/modules.md#best-practice-for-loading-modules) for more information.
 <!-- markdownlint-disable MD046 -->
+
+<!-- markdownlint-disable MD046 -->
+!!! note
+
+    The latest CUDA and cuDNN are now available from [Conda](#cuda-and-cudnn-modules).
+<!-- markdownlint-enable MD046 -->
 
 ## Reviewing GPU Jobs
 
@@ -157,7 +171,7 @@ As with all jobs, use [`sacct`](job_management.md#reviewing-past-jobs-with-sacct
     We intend to retain all of the 18 existing P100 GPU nodes, of which  9 nodes are available now. The remaining 9 nodes have been temporarily taken offline as we reconfigure hardware, and will be reallocated based on demand and other factors.
 - **What else should I be aware of?**
     - Please be sure to clean your data off of `/local/$SLURM_JOB_ID` as soon as you no longer need it, before the job finishes.
-    - We have updated the CUDA and cuDNN modules to improve reliability and ease of use. Please see the section on [CUDA Modules](#cuda-modules) for more information.
+    - We have updated the CUDA and cuDNN modules to improve reliability and ease of use. Please see the section on [CUDA Modules](#cuda-and-cudnn-modules) for more information.
     - GPU-based software, such as Parabricks, Triton, etc., requires a [CUDA Compute Capability](../slurm/gpu.md/#available-devices) greater than 6.0 for proper execution and should be run on the `amperenodes` partition. Some of the software that encountered runtime errors due to the underlying issues were,
         - [Parabricks](../../education/case_studies.md/#minimum-hardware-requirements-to-run-parabricks-on-cheaha-gpus)
         - [Triton](https://docs.nvidia.com/deeplearning/triton-inference-server/archives/triton_inference_server_1140/user-guide/docs/build.html#configure-triton-build)

--- a/docs/cheaha/slurm/gpu.md
+++ b/docs/cheaha/slurm/gpu.md
@@ -92,9 +92,9 @@ As of 2025-02-25, we offer CUDA modules up to version `12.6.0`. If you need a ne
 
 {{ read_csv('cheaha/slurm/res/cuda_conda_package_versions.csv', keep_default_na=False) }}
 
-If working with deep neural networks (DNNs, CNNs, LSTMs, LLMs, AI, etc.), you will need to load a `cuDNN` module as well. The `cuDNN` modules are built to be compatible with a sibling `CUDA` module and are named with the corresponding version. For example, if you are loading `CUDA/12.2.0`, you will also need to load `cuDNN/8.9.2.26-CUDA-12.2.0`.
+If you are working with deep neural networks (DNNs, CNNs, LSTMs, LLMs, AI, etc.), you will also need to load a `cuDNN`. The `cuDNN` modules are built to be compatible with a sibling `CUDA` module and are named with the corresponding `CUDA` version. For example, if you are loading `CUDA/12.2.0`, you will also need to load `cuDNN/8.9.2.26-CUDA-12.2.0`. Note the trailing `12.2.0`.
 
-As of 2025-02-25, we offer cuDNN modules compatible with CUDA up to version `12.3.0`. If you need a newer version, please use [Conda](../software/software.md#anaconda-on-cheaha) to install cuDNN software from the `conda-forge` channel. The packages and relevant commands to install into your newly created [environment](../../workflow_solutions/using_anaconda.md#create-an-environment) are available at <https://anaconda.org/conda-forge/cudnn>.
+As of 2025-02-25, we offer cuDNN modules for CUDA up to `12.3.0`. If you need a newer version, please use [Conda](../software/software.md#anaconda-on-cheaha) to install cuDNN software from the `conda-forge` channel. More details on how to install `CUDA` and `cuDNN` into your [environment](../../workflow_solutions/using_anaconda.md#create-an-environment) are available at <https://anaconda.org/conda-forge/cudnn>.
 
 ### CUDA Compute Capability and Known Issues
 

--- a/docs/cheaha/slurm/res/cuda_conda_package_versions.csv
+++ b/docs/cheaha/slurm/res/cuda_conda_package_versions.csv
@@ -1,0 +1,3 @@
+CUDA version required,Package required,URL
+`11.x` and below (`< 12.0`),`cuda-toolkit`,https://anaconda.org/conda-forge/cuda-toolkit
+`12.x` and above (`>= 12.0`),`cuda-cudart`,https://anaconda.org/conda-forge/cuda-cudart

--- a/docs/cheaha/slurm/res/cuda_conda_package_versions.csv
+++ b/docs/cheaha/slurm/res/cuda_conda_package_versions.csv
@@ -1,3 +1,3 @@
 CUDA version required,Package required,URL
-`11.x` and below (`< 12.0`),`cuda-toolkit`,https://anaconda.org/conda-forge/cuda-toolkit
-`12.x` and above (`>= 12.0`),`cuda-cudart`,https://anaconda.org/conda-forge/cuda-cudart
+`11.x` and below (`< 12.0`),`cuda-toolkit`,<https://anaconda.org/conda-forge/cuda-toolkit>
+`12.x` and above (`>= 12.0`),`cuda-cudart`,<https://anaconda.org/conda-forge/cuda-cudart>

--- a/docs/cheaha/slurm/slurm_tutorial.md
+++ b/docs/cheaha/slurm/slurm_tutorial.md
@@ -6,6 +6,12 @@ toc_depth: 3
 
 This Slurm tutorial serves as a hands-on guide for users to create Slurm batch scripts based on their specific software needs and apply them for their respective usecases.  It covers basic examples for beginners and advanced ones, including sequential and parallel jobs, array jobs, multithreaded jobs, GPU utilization jobs, and MPI (Message Passing Interface) jobs. To know which type of batch jobs are suitable for your pipeline/usecase, please refer to the [User Guide](#slurm-batch-job-user-guide) section.
 
+<!-- markdownlint-disable MD046 -->
+!!! note
+
+    CUDA modules are used in some of these tutorials. Please note that the latest CUDA and cuDNN are now available from [Conda](../slurm/gpu.md#cuda-and-cudnn-modules). The tutorials provide good practices, but age over time. You may need to modify the scripts to be suitable for your work.
+<!-- markdownlint-enable MD046 -->
+
 ## Structure of a Slurm Batch Job
 
 Below is the template for a typical Slurm job submission in the Cheaha high-performance computing (HPC) system. The script begins with `#!/bin/bash`, indicating it is a bash script. The next step would be to declare Slurm configuration options, specifying the required resources for job execution. This section typically comprises parameters such as CPU count, partition, memory allocation, time limit, etc. Following the configuration, the script may include sections for loading necessary software or libraries required for the job.

--- a/docs/cheaha/software/modules.md
+++ b/docs/cheaha/software/modules.md
@@ -156,6 +156,12 @@ When using modules in Cheaha, we recommend users to follow these best practices 
 
 Using `module reset` before loading modules separates what software is loaded in the working shell from the software loaded in the script shell. Be aware that forked processes (like scripts) and Slurm commands inherit the environment variables of the working shell, including loaded modules. Here is an example that shows module conflict between cuda11.8 and cuda11.4 versions that may lead to unexpected behavior or an erroneous output.
 
+<!-- markdownlint-disable MD046 -->
+!!! note
+
+    The latest CUDA and cuDNN are now available from [Conda](../slurm/gpu.md#cuda-and-cudnn-modules).
+<!-- markdownlint-enable MD046 -->
+
 ```bash
 # Working shell where you may try testing module load and your run script
 $ module load cuda11.4/toolkit

--- a/docs/cheaha/software/software.md
+++ b/docs/cheaha/software/software.md
@@ -48,6 +48,10 @@ Anaconda on Cheaha works like it does on any other system, once the module has b
 
 For more information on usage with examples, see [Anaconda Environments](../../workflow_solutions/using_anaconda.md). Need some hands-on experience, you can find instructions on how to install PyTorch and TensorFlow using Anaconda in this [tutorial](../tutorial/pytorch_tensorflow.md).
 
+### Obtaining the Latest CUDA and cuDNN Modules
+
+Please see our [CUDA and cuDNN section of the GPU page](../slurm/gpu.md#cuda-and-cudnn-modules).
+
 ## Singularity Containers
 
 Containers are a very useful resource for installing software without needing administrator permission. Please read the full documentation about singularity and containers on our [main Singularity page](../../workflow_solutions/getting_containers.md#containers-on-cheaha).

--- a/docs/cheaha/tutorial/pytorch_tensorflow.md
+++ b/docs/cheaha/tutorial/pytorch_tensorflow.md
@@ -2,6 +2,12 @@
 
 The below tutorial would show you steps on how to create an Anaconda environment, activate, and install libraries/packages for machine and deep learning (PyTorch and Tensorflow) using an Anaconda environment on Cheaha. There are also steps on how to access the terminal, as well as using Jupyter Notebook's Graphical User Interface (GUI) to work with these Anaconda environments. There are detailed steps here to guide your creation of a [Jupyter Notebook job.](../open_ondemand/ood_layout.md#interactive-apps)
 
+<!-- markdownlint-disable MD046 -->
+!!! note
+
+    CUDA modules are used in this tutorial. Please note that the latest CUDA and cuDNN are now available from [Conda](../slurm/gpu.md#cuda-and-cudnn-modules). The tutorial provides good practices, but ages over time. You may need to modify the scripts to be suitable for your work.
+<!-- markdownlint-enable MD046 -->
+
 ## Installing Anaconda Environments Using the Terminal
 
 To access the terminal (shell), please do the following.
@@ -57,8 +63,7 @@ module load CUDA/11.8.0
 <!-- markdownlint-disable MD046 -->
 !!! note
 
-    The cudatoolkit version may vary, as at the time of this tutorial, 11.8 is the version used. Running `nvidia-smi`, as in the image below, will show you the status, version and other information on GPUs in your created job session. The CUDA version is highlighted. The GPU CUDA Version available on Cheaha at the time of this tutorial is 12.3. Because the toolkit version used is lower than the Cheaha GPU version, it works.
-
+    The cudatoolkit version may vary, as at the time of this tutorial, 11.8 is the version used. Running `nvidia-smi`, as in the image below, will show you the status, version and other information on GPUs in your created job session. The CUDA version is highlighted. The GPU CUDA Version available on Cheaha as of 2025-02-25 is `12.6.0`. Newer versions are available from [Conda](../slurm/gpu.md#cuda-and-cudnn-modules). Because the toolkit version used is lower than the Cheaha GPU version, it works.
 <!-- markdownlint-enable MD046 -->
 
 ![!nvidia-smi output](images/CudaVersion.png)

--- a/docs/education/case_studies.md
+++ b/docs/education/case_studies.md
@@ -4,7 +4,13 @@
 
 A GPU-accelerated genome sequencing analysis with high speedup and more accurate results can be achieved with NVIDIA Clara Parabricks. Pararbricks is a software suite for genomic analysis. Parabricks delivers accelerated analysis of next generation sequencing (NGS) data for researchers, RNA-seq, population studies, and many more usecases. More insights on its performance can be found [here](https://resources.nvidia.com/en-us-genomics-ep/genomics-appliance-for-research?lx=OhKlSJ).
 
-For more information on Cheaha GPUs, please see our [GPU Page](../cheaha/slurm/gpu.md)
+For more information on Cheaha GPUs, please see our [GPU Page](../cheaha/slurm/gpu.md).
+
+<!-- markdownlint-disable MD046 -->
+!!! note
+
+    CUDA modules are used in this case study. Please note that the latest CUDA and cuDNN are now available from [Conda](../cheaha/slurm/gpu.md#cuda-and-cudnn-modules).
+<!-- markdownlint-enable MD046 -->
 
 ### Licensing Policy
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,9 @@ The Research Computing System (RCS) provides a framework for sharing research da
 
     We have released new A100 gpus on Cheaha! For more information please see [GPUs](cheaha/slurm/gpu.md).
 
-    We have released new CUDA and cuDNN modules! For more information please see [CUDA Modules](cheaha/slurm/gpu.md#cuda-modules).
+    The latest CUDA and cuDNN software is now available from [Conda](./cheaha/slurm/gpu.md#cuda-and-cudnn-modules).
 
-    Also see our [A100 GPU Frequently Asked Questions (FAQ)](cheaha/slurm/gpu.md#frequently-asked-questions-faq-about-a100-gpus)
+    Also see our [A100 GPU Frequently Asked Questions (FAQ)](cheaha/slurm/gpu.md#frequently-asked-questions-faq-about-a100-gpus).
 <!-- markdownlint-enable MD046 -->
 
 ## How to Contact Us

--- a/docs/workflow_solutions/using_anaconda.md
+++ b/docs/workflow_solutions/using_anaconda.md
@@ -115,6 +115,10 @@ You may use the [Anaconda page](https://anaconda.org/) to search for packages on
 
 For more information about using Anaconda with Jupyter, see the section [Working with Anaconda Environments](../cheaha/open_ondemand/ood_jupyter.md#working-with-anaconda-environments).
 
+#### CUDA and cuDNN packages for GPU Usage
+
+For more information about finding CUDA and cuDNN packages for use with GPUs, see the section [CUDA and cuDNN Modules](../cheaha/slurm/gpu.md#cuda-and-cudnn-modules)
+
 ### Update packages in an environment
 
 To ensure packages and their dependencies are all up to date, it is a best practice to regularly update installed packages, and libraries in your activated environment.


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

<!-- Briefly summarize the proposed changes -->

Adds information on how to get the latest CUDA and cuDNN packages from conda.

## Proposed Changes

<!-- Provide specific details of what is changing -->

- Adds information to central location in GPU page
- Merges CUDA and cuDNN sections on GPU page
- Adds reference note to tutorials and case studies making use of CUDA modules
- Adds reference to pages for software commonly used with GPUs such as Jupyter
- Adds reference to conda section in workflow solutions software page

## Related Issues

Fixes #875 
