### PR TITLE
switching between lts allocation profiles

### DIFF
--- a/docs/data_management/lts/interfaces.md
+++ b/docs/data_management/lts/interfaces.md
@@ -251,6 +251,14 @@ It's important to note that the main functionality of s5cmd over s3cmd is the pa
     When setting the value for `--numworkers`, do not select a value beyond the number of CPUs you have requested for your job! This can cause high context switching (meaning individual CPUs are switching between multiple running processes) which can affect job performance for all jobs on a node.
 <!-- markdownlint-enable MD046 -->
 
+#### Switching Between LTS Allocations Profiles
+
+By default, `s5cmd` uses the `[default]` profile. To use a different profile, specify the `--profile` flag. For example, to copy all files from a local directory to a bucket in a shared LTS allocation using a single CPU, run the following command:
+
+`s5cmd --endpoint-url https://s3.lts.rc.uab.edu --profile <shared-allocation-profile-name> cp /path/to/directory/* s3://bucket/`
+
+Replace `<shared-allocation-profile-name>` with the profile name defined for your shared LTS allocation in your `~/.aws/credentials` file.
+
 ### Installation of `s3cmd` and `s5cmd` on Individual Systems Without Anaconda
 
 The installation instructions and software dependencies may differ depending on the operating system being used. Following are the installation instructions tested for different operating systems. You may also use [Anaconda](../../workflow_solutions/using_anaconda.md) to install either or both packages.


### PR DESCRIPTION
# Pull Request

<!-- PLEASE READ THE COMMENTS BELOW -->

## Overview

<!-- Briefly summarize the proposed changes -->
The aim of this PR is to add documentation on how to switch between LTS allocation profiles when using `s5cmd` to transfer data from a local directory to LTS.
## Proposed Changes

<!-- Provide specific details of what is changing -->
- Added a section "Switching Between LTS Allocations" in interfacing with LTS page
- Added an example `s5cmd` command demonstrating usage with the shared LTS profile.
### Changes to Section Headers
N/A
<!--
Write down which headers have changed.

old-header -> new-header
-->

### Changes to Page URLs
N/A
<!--
Write down which pages have changed.

old/page.md -> new/page.md
-->

## Accessibility Checklist

- [ ] All images have appropriate alt text. [Guidelines](https://www.wcag.com/blog/good-alt-text-bad-alt-text-making-your-content-perceivable/)
- [ ] Text-based images have appropriate contrast ratio. [Checker](https://webaim.org/resources/contrastchecker/)
- [ ] Text-based image content is transcribed in body text.
- [ ] Abbreviations are introduced before usage in body text.

## Style Checklist

- [ ] My content crosslinks to other relevant pages.
- [ ] Other relevant pages crosslink to my content.
- [ ] I have added redirects for any moved headers or pages.
- [ ] New jargon terms are defined in the glossary.
- [ ] Existing jargon terms are crosslinked to the glossary.
- [ ] Proper nouns and branded names are written and/or introduced properly. [List here](https://docs.rc.uab.edu/contributing/contributor_guide/#terminology).

## Related Issues
Fixes #1015 
Fixes #990
<!--
Examples:
Fixes #123
Related to #101
-->
